### PR TITLE
add load_generator

### DIFF
--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -100,6 +100,26 @@ The `load` method loads individual task input by passing a key of an input dicti
         data_b = self.load('b')
 
 
+TaskOnKart.load_generator
+----------------
+The :func:`~gokart.task.TaskOnKart.load_generator` method is used to load input data with generator.
+For instance, an example implementation could be as follows:
+
+.. code:: python
+
+    def requires(self):
+        return TaskA(param='called by TaskB')
+
+    def run(self):
+        for data in self.load_generator():
+            any_process(data)
+
+
+Usage is the same as `TaskOnKart.generator`.
+`load_generator` reads the divided file into iterations.
+It's effective when can't read all data in memory, because `load_generator` doesn't load all files at once.
+
+
 TaskOnKart.dump
 ----------------
 The :func:`~gokart.task.TaskOnKart.dump` method is used to dump results of tasks.

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -117,7 +117,7 @@ For instance, an example implementation could be as follows:
 
 Usage is the same as `TaskOnKart.generator`.
 `load_generator` reads the divided file into iterations.
-It's effective when can't read all data in memory, because `load_generator` doesn't load all files at once.
+It's effective when can't read all data to memory, because `load_generator` doesn't load all files at once.
 
 
 TaskOnKart.dump

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -138,6 +138,19 @@ class TaskOnKart(luigi.Task):
 
         return _load(self._get_input_targets(target))
 
+    def load_generator(self, target: Union[None, str, TargetOnKart] = None) -> Any:
+        def _load(targets):
+            if isinstance(targets, list):
+                for t in targets:
+                    yield from _load(t)
+            elif isinstance(targets, dict):
+                for k, t in targets.items():
+                    yield from {k: _load(t)}
+            else:
+                yield targets.load()
+
+        return _load(self._get_input_targets(target))
+
     def load_data_frame(self,
                         target: Union[None, str, TargetOnKart] = None,
                         required_columns: Optional[Set[str]] = None) -> pd.DataFrame:

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -132,6 +132,22 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(data['target_key_1'], 1)
         self.assertEqual(data['target_key_2'], 2)
 
+    def test_load_generator_with_single_target(self):
+        task = _DummyTask()
+        target = MagicMock(spec=TargetOnKart)
+        target.load.return_value = [1,2]
+        task.input = MagicMock(return_value=target)
+        data = [x for x in task.load_generator()]
+        self.assertEqual(data, [[1,2]])
+
+    def test_load_with_keyword(self):
+        task = _DummyTask()
+        target = MagicMock(spec=TargetOnKart)
+        target.load.return_value = [1,2]
+        task.input = MagicMock(return_value={'target_key': target})
+        data = [x for x in task.load_generator('target_key')]
+        self.assertEqual(data, [[1,2]])
+
     def test_dump(self):
         task = _DummyTask()
         target = MagicMock(spec=TargetOnKart)


### PR DESCRIPTION
https://github.com/m3dev/gokart/issues/47

usage:
```
class Hoge(gokart.TaskOnKart):

    ...

    def run(self):
        result = []
        for x in self.load_generator():
            result.append( proccess_file(x) )
       self.dump(result)
```

`load_generator` reads the divided file into iterations.
It's effective when can't read all data to memory, because `load_generator` doesn't load all files at once.