### PR TITLE
add setuptools_scm for removing verup annoying procedure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ install_requires = [
 
 setup(
     name='gokart',
-    version='0.1.17',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     description='A wrapper of luigi. This make it easy to define tasks.',
     long_description=long_description,
     author='M3, inc.',


### PR DESCRIPTION
Since we tend to forget update version number in setup.py, I add setuptools_scm for detecting version number from git tag automatically.