### PR TITLE
minimum change for migrate slackclient v2

### DIFF
--- a/gokart/slack/slack_api.py
+++ b/gokart/slack/slack_api.py
@@ -1,6 +1,7 @@
 from logging import getLogger
 
-from slackclient import SlackClient
+from slack import WebClient
+
 
 logger = getLogger(__name__)
 
@@ -19,7 +20,7 @@ class FileNotUploadedError(RuntimeError):
 
 class SlackAPI(object):
     def __init__(self, token, channel: str, to_user: str) -> None:
-        self._client = SlackClient(token=token)
+        self._client = WebClient(token=token)
         self._channel_id = self._get_channel_id(channel)
         self._to_user = to_user if to_user == '' or to_user.startswith('@') else '@' + to_user
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'luigi',
     'python-dateutil==2.7.5',
     'boto3',
-    'slackclient',
+    'slackclient>=2.0.0',
     'pandas',
     'numpy',
     'tqdm',

--- a/test/slack/test_slack_api.py
+++ b/test/slack/test_slack_api.py
@@ -9,7 +9,7 @@ logger = getLogger(__name__)
 
 
 class TestSlackAPI(unittest.TestCase):
-    @mock.patch('gokart.slack.slack_api.SlackClient')
+    @mock.patch('gokart.slack.slack_api.WebClient')
     def test_initialization_with_invalid_token(self, patch):
         def _channels_list(method):
             assert method == 'channels.list'
@@ -22,7 +22,7 @@ class TestSlackAPI(unittest.TestCase):
         with self.assertRaises(gokart.slack.slack_api.ChannelListNotLoadedError):
             gokart.slack.SlackAPI(token='invalid', channel='test', to_user='test user')
 
-    @mock.patch('gokart.slack.slack_api.SlackClient')
+    @mock.patch('gokart.slack.slack_api.WebClient')
     def test_invalid_channel(self, patch):
         def _channels_list(method):
             assert method == 'channels.list'
@@ -35,7 +35,7 @@ class TestSlackAPI(unittest.TestCase):
         with self.assertRaises(gokart.slack.slack_api.ChannelNotFoundError):
             gokart.slack.SlackAPI(token='valid', channel='invalid_channel', to_user='test user')
 
-    @mock.patch('gokart.slack.slack_api.SlackClient')
+    @mock.patch('gokart.slack.slack_api.WebClient')
     def test_send_snippet_with_invalid_token(self, patch):
         def _api_call(*args, **kwargs):
             if args[0] == 'channels.list':
@@ -52,7 +52,7 @@ class TestSlackAPI(unittest.TestCase):
             api = gokart.slack.SlackAPI(token='valid', channel='valid', to_user='test user')
             api.send_snippet(comment='test', title='title', content='content')
 
-    @mock.patch('gokart.slack.slack_api.SlackClient')
+    @mock.patch('gokart.slack.slack_api.WebClient')
     def test_send(self, patch):
         def _api_call(*args, **kwargs):
             if args[0] == 'channels.list':


### PR DESCRIPTION
This PR migrate to slackclient v2 by minimum modifications.

I've not applied modifications show in below URL which are recommended in slackclient package.
https://github.com/slackapi/python-slackclient/blob/master/slack/web/client.py#L35

These are remaining in future task.