### PR TITLE
let CsvFileProcessor.dump accepts a pd.Series argument

### DIFF
--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -104,8 +104,9 @@ class CsvFileProcessor(FileProcessor):
             return pd.DataFrame()
 
     def dump(self, obj, file):
-        assert isinstance(obj, pd.DataFrame), f'requires pd.DataFrame, but {type(obj)} is passed.'
-        obj.to_csv(file, index=False, sep=self._sep)
+        assert isinstance(obj, (pd.DataFrame, pd.Series)), \
+            f'requires pd.DataFrame or pd.Series, but {type(obj)} is passed.'
+        obj.to_csv(file, index=False, sep=self._sep, header=True)
 
 
 class GzipFileProcessor(FileProcessor):

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -83,6 +83,16 @@ class LocalTargetTest(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             target.last_modification_time()
 
+    def test_save_pandas_series(self):
+        obj = pd.Series(data=[1, 2], name='column_name')
+        file_path = os.path.join(_get_temporary_directory(), 'test.csv')
+
+        target = make_target(file_path=file_path, unique_id=None)
+        target.dump(obj)
+        loaded = target.load()
+
+        pd.testing.assert_series_equal(loaded['column_name'], obj)
+
 
 class S3TargetTest(unittest.TestCase):
     @mock_s3


### PR DESCRIPTION
At the moment, the `CsvFileProcessor.dump` method only takes a `pd.DataFrame` object as an argument. However, it should also accept `pd.Series`, since both `pd.DataFrame` and `pd.Series` classes implement the `to_csv` method.