### PR TITLE
change load Slack and S3 token method

### DIFF
--- a/gokart/gcs_config.py
+++ b/gokart/gcs_config.py
@@ -9,4 +9,4 @@ class GCSConfig(luigi.Config):
 
     def get_gcs_client(self) -> luigi.contrib.gcs.GCSClient:
         return luigi.contrib.gcs.GCSClient(
-            oauth_credentials=os.environ.get(self.gcs_credential_name))
+            oauth_credentials=os.getenv(self.gcs_credential_name, self.gcs_credential_name))

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -71,7 +71,7 @@ def _try_to_delete_unnecessary_output_file(cmdline_args: List[str]):
 def _try_get_slack_api(cmdline_args: List[str]) -> Optional[gokart.slack.SlackAPI]:
     with CmdlineParser.global_instance(cmdline_args):
         config = gokart.slack.SlackConfig()
-        token = os.getenv(config.token_name, '')
+        token = config.token_name
         channel = config.channel
         to_user = config.to_user
         if token and channel:

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -71,7 +71,7 @@ def _try_to_delete_unnecessary_output_file(cmdline_args: List[str]):
 def _try_get_slack_api(cmdline_args: List[str]) -> Optional[gokart.slack.SlackAPI]:
     with CmdlineParser.global_instance(cmdline_args):
         config = gokart.slack.SlackConfig()
-        token = config.token_name
+        token = os.getenv(config.token_name, config.token_name)
         channel = config.channel
         to_user = config.to_user
         if token and channel:

--- a/gokart/s3_config.py
+++ b/gokart/s3_config.py
@@ -11,5 +11,5 @@ class S3Config(luigi.Config):
 
     def get_s3_client(self) -> luigi.contrib.s3.S3Client:
         return luigi.contrib.s3.S3Client(
-            aws_access_key_id=os.environ.get(self.aws_access_key_id_name),
-            aws_secret_access_key=os.environ.get(self.aws_secret_access_key_name))
+            aws_access_key_id=os.getenv(self.aws_access_key_id_name, self.aws_access_key_id_name),
+            aws_secret_access_key=os.getenv(self.aws_secret_access_key_name, self.aws_secret_access_key_name))


### PR DESCRIPTION
We already have a way to read environment variables in config > `%(hoge)s`
```
[SlackConfig]
token_name=%(SLACK_TOKEN)s
channel=lambda_test
to_user=vanquish
```
We don't need to use `os.getenv` only for Slack.