### PR TITLE
fix gokart logger

### DIFF
--- a/gokart/run.py
+++ b/gokart/run.py
@@ -71,7 +71,7 @@ def _try_to_delete_unnecessary_output_file(cmdline_args: List[str]):
 def _try_get_slack_api(cmdline_args: List[str]) -> Optional[gokart.slack.SlackAPI]:
     with CmdlineParser.global_instance(cmdline_args):
         config = gokart.slack.SlackConfig()
-        token = os.getenv(config.token_name, '')
+        token = config.token_name
         channel = config.channel
         to_user = config.to_user
         if token and channel:

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -2,7 +2,7 @@ import configparser
 import os
 import sys
 from configparser import ConfigParser
-from logging import getLogger
+from logging import getLogger, config
 from typing import List, Optional
 
 import luigi
@@ -30,6 +30,17 @@ def _check_config():
             parser.items(section)
         except configparser.InterpolationMissingOptionError as e:
             raise luigi.parameter.MissingParameterException(f'Environment variable "{e.args[3]}" must be set.')
+
+
+def _load_logging_conf(cmdline_args):
+    parser = luigi.configuration.LuigiConfigParser.instance()
+    try:
+        items = parser.items('core')
+    except:
+        items = []
+    for item in items:
+        if item[0] == 'logging_conf_file':
+            config.fileConfig(item[1], disable_existing_loggers=False)
 
 
 def _run_tree_info(cmdline_args, details):
@@ -114,6 +125,7 @@ def run(cmdline_args=None, set_retcode=True):
 
     _read_environ()
     _check_config()
+    _load_logging_conf(cmdline_args)
     _try_tree_info(cmdline_args)
     _try_to_delete_unnecessary_output_file(cmdline_args)
 

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -82,7 +82,7 @@ def _try_to_delete_unnecessary_output_file(cmdline_args: List[str]):
 def _try_get_slack_api(cmdline_args: List[str]) -> Optional[gokart.slack.SlackAPI]:
     with CmdlineParser.global_instance(cmdline_args):
         config = gokart.slack.SlackConfig()
-        token = config.token_name
+        token = os.getenv(config.token_name, config.token_name)
         channel = config.channel
         to_user = config.to_user
         if token and channel:


### PR DESCRIPTION
We were not doing gokart logging.

Because, Settings written in `core sections` can't be read.  
This is a matter of order.
```
[gokart.run] --> [part of gokart logging] --> [luigi._schedule_and_run(load log.ini)]
```
```
[core]
logging_conf_file=./log.ini
```

We need to load core.logging_conf_file in advance.