### PR TITLE
rm require pyhton-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'), encoding
 
 install_requires = [
     'luigi',
-    'python-dateutil==2.7.5',
     'boto3',
     'slackclient>=2.0.0',
     'pandas',


### PR DESCRIPTION
We fixed python-dateutil version.  Now it is unnecessary :)
- reference 
https://github.com/spotify/luigi/issues/2662, https://github.com/spotify/luigi/blob/master/setup.py#L40
