### PR TITLE
Add parquet support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ install_requires = [
     'pandas',
     'numpy',
     'tqdm',
-    'google-auth'
+    'google-auth',
+    'pyarrow'
 ]
 
 setup(

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -79,6 +79,16 @@ class LocalTargetTest(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, obj)
 
+    def test_save_and_load_parquet(self):
+        obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))
+        file_path = os.path.join(_get_temporary_directory(), 'test.parquet')
+
+        target = make_target(file_path=file_path, unique_id=None)
+        target.dump(obj)
+        loaded = target.load()
+
+        pd.testing.assert_frame_equal(loaded, obj)
+
     def test_last_modified_time(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))
         file_path = os.path.join(_get_temporary_directory(), 'test.csv')


### PR DESCRIPTION
I've added parquet extension ( `*.parquet` files) to make it easy to import data into BigQuery.

see: [BigQuery - Loading Parquet data from Cloud Storage](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet)