### PR TITLE
LargeDataFrameProcessor can handle list/dict of dataframes

### DIFF
--- a/gokart/target.py
+++ b/gokart/target.py
@@ -176,11 +176,7 @@ class LargeDataFrameProcessor(object):
 
     @staticmethod
     def load_recursively(dir_path: pathlib.Path):
-        print(f'load: {dir_path}')
         if (dir_path / 'data_0.pkl').exists():
-            for file_path in dir_path.glob('data_*.pkl'):
-                print(f'load_pickle: {file_path}')
-
             return pd.concat([pd.read_pickle(str(file_path)) for file_path in dir_path.glob('data_*.pkl')])
         elif (dir_path / '0').exists():
 

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -140,7 +140,13 @@ class LargeDataFrameProcessor(object):
     def __init__(self, max_byte: int):
         self.max_byte = int(max_byte)
 
-    def save(self, df: pd.DataFrame, file_path: str):
+    def save(self, target_object: object, file_path: str):
+        if isinstance(target_object, pd.DataFrame):
+            self._save_dataframe(target_object, file_path=file_path)
+        else:
+            raise ValueError('target_object must be DataFrame')
+
+    def _save_dataframe(self, df: pd.DataFrame, file_path: str):
         dir_path = os.path.dirname(file_path)
         os.makedirs(dir_path, exist_ok=True)
 

--- a/test/test_large_data_frame_processor.py
+++ b/test/test_large_data_frame_processor.py
@@ -25,6 +25,23 @@ class LargeDataFrameProcessorTest(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, df, check_like=True)
 
+    def test_save_dictionary_and_list(self):
+        file_path = os.path.join(_get_temporary_directory(), 'test_save_dictionary_and_list.zip')
+        test_object = {
+            "a": [
+                pd.DataFrame(dict(data=np.random.uniform(0, 1, size=int(1e+6)))),
+                pd.DataFrame(dict(data=np.random.uniform(0, 1, size=int(1e+6)))),
+            ],
+            "b": pd.DataFrame(dict(data=np.random.uniform(0, 1, size=int(1e+6))))
+        }
+        processor = LargeDataFrameProcessor(max_byte=int(1e+6))
+        processor.save(test_object, file_path)
+        loaded = processor.load(file_path)
+
+        pd.testing.assert_frame_equal(loaded["a"][0], test_object["a"][0], check_like=True)
+        pd.testing.assert_frame_equal(loaded["a"][1], test_object["a"][1], check_like=True)
+        pd.testing.assert_frame_equal(loaded["b"], test_object["b"], check_like=True)
+
     def test_save_and_load_empty(self):
         file_path = os.path.join(_get_temporary_directory(), 'test_with_empty.zip')
         df = pd.DataFrame()


### PR DESCRIPTION
Currently LargeDataFrameProcessor (or its inteface `TaskOnKart.make_large_data_frame_target`) supports only dataframe. 
This PR enables it to handle list/dict of dataframes as follows

```
class Task(TaskOnKart):
    def output(self):
        return self.make_large_data_frame_target('data.zip')

    def run(self):
        self.dump({
            "a": [
                pd.DataFrame(dict(data=np.random.uniform(0, 1, size=int(1e+6)))),
                pd.DataFrame(dict(data=np.random.uniform(0, 1, size=int(1e+6)))),
            ],
            "b": pd.DataFrame(dict(data=np.random.uniform(0, 1, size=int(1e+6))))
        })

```