### PR TITLE
make default TaskOnKart.requires

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -61,8 +61,11 @@ class TaskOnKart(luigi.Task):
         return self.make_target(os.path.join(file_path, f"{type(self).__name__}.pkl"))
 
     def requires(self):
-        tasks = {key[:-5]: var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
+        tasks = self.make_task_instance_dictionary()
         return tasks or []  # when tasks is empty dict, then this returns empty list.
+
+    def make_task_instance_dictionary(self) -> Dict[str, 'TaskOnKart']:
+        return {key[:-5]: var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
 
     @classmethod
     def _add_configuration(cls, kwargs, section):

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -7,7 +7,6 @@ from typing import Union, List, Any, Callable, Set, Optional, Dict
 
 import luigi
 import pandas as pd
-from luigi.task_register import Register
 
 import gokart
 from gokart.file_processor import FileProcessor
@@ -65,7 +64,7 @@ class TaskOnKart(luigi.Task):
         return tasks or []  # when tasks is empty dict, then this returns empty list.
 
     def make_task_instance_dictionary(self) -> Dict[str, 'TaskOnKart']:
-        return {key[:-5]: var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
+        return {key: var for key, var in vars(self).items() if isinstance(var, TaskOnKart)}
 
     @classmethod
     def _add_configuration(cls, kwargs, section):

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -65,7 +65,7 @@ class TaskOnKart(luigi.Task):
         return tasks or []  # when tasks is empty dict, then this returns empty list.
 
     def make_task_instance_dictionary(self) -> Dict[str, 'TaskOnKart']:
-        return {key[:-5]: var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
+        return {key.rstrip('_task'): var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
 
     @classmethod
     def _add_configuration(cls, kwargs, section):

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -60,6 +60,10 @@ class TaskOnKart(luigi.Task):
         file_path = self.__module__.replace(".", "/")
         return self.make_target(os.path.join(file_path, f"{type(self).__name__}.pkl"))
 
+    def requires(self):
+        tasks = {key[:-5]: var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
+        return tasks or []  # when tasks is empty dict, then this returns empty list.
+
     @classmethod
     def _add_configuration(cls, kwargs, section):
         config = luigi.configuration.get_config()

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -65,7 +65,7 @@ class TaskOnKart(luigi.Task):
         return tasks or []  # when tasks is empty dict, then this returns empty list.
 
     def make_task_instance_dictionary(self) -> Dict[str, 'TaskOnKart']:
-        return {key.rstrip('_task'): var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
+        return {key[:-5]: var for key, var in vars(self).items() if key.endswith('_task') and isinstance(var, TaskOnKart)}
 
     @classmethod
     def _add_configuration(cls, kwargs, section):

--- a/test/test_restore_task_by_id.py
+++ b/test/test_restore_task_by_id.py
@@ -16,6 +16,9 @@ class _DummyTask(gokart.TaskOnKart):
     task_namespace = __name__
     sub_task = gokart.TaskInstanceParameter()
 
+    def requires(self):
+        return []
+
     def output(self):
         return self.make_target('test.txt')
 

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -4,9 +4,8 @@ import unittest
 from datetime import datetime
 
 import boto3
-import pandas as pd
 import numpy as np
-import numpy.testing
+import pandas as pd
 from moto import mock_s3
 
 from gokart.target import make_target, make_model_target

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -291,6 +291,20 @@ class TaskTest(unittest.TestCase):
         self.assertNotEqual(x_task.make_unique_id(), y_task.make_unique_id())
         self.assertEqual(y_task.make_unique_id(), z_task.make_unique_id())
 
+    def test_default_requires(self):
+        class _WithoutTaskInstanceParameter(gokart.TaskOnKart):
+            task_namespace = __name__
+
+        class _WithTaskInstanceParameter(gokart.TaskOnKart):
+            task_namespace = __name__
+            a_task = gokart.TaskInstanceParameter()
+
+        without_task = _WithoutTaskInstanceParameter()
+        self.assertListEqual(without_task.requires(), [])
+
+        with_task = _WithTaskInstanceParameter(a_task=without_task)
+        self.assertEqual(with_task.requires()['a'], without_task)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -303,7 +303,7 @@ class TaskTest(unittest.TestCase):
         self.assertListEqual(without_task.requires(), [])
 
         with_task = _WithTaskInstanceParameter(a_task=without_task)
-        self.assertEqual(with_task.requires()['a'], without_task)
+        self.assertEqual(with_task.requires()['a_task'], without_task)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When a task has instances of TaskInstanceParameter, then default `requires` function returns dictionary of these instances as follows:

```python
class SomeTask(gokart.TaskOnKart):
    a_task = gokart.TaskInstanceParameter()
    b_task = gokart.TaskInstanceParameter()

    # This PR makes the following function automatically.
    def requires(self):
        return dict(a=self.a_task, b=self.b_task)
```