### PR TITLE
Fix to use _LargeLocalFileReader for local (and GCS) files

### DIFF
--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -31,7 +31,7 @@ class FileProcessor(object):
         pass
 
 
-class _LargeLocalFileReader(object):
+class _ChunkedLargeFileReader(object):
     def __init__(self, file) -> None:
         self._file = file
 
@@ -58,9 +58,9 @@ class PickleFileProcessor(FileProcessor):
         return luigi.format.Nop
 
     def load(self, file):
-        if ObjectStorage.is_readable_objectstorage_instance(file):
+        if not ObjectStorage.is_buffered_reader(file):
             return pickle.loads(file.read())
-        return pickle.load(_LargeLocalFileReader(file))
+        return pickle.load(_ChunkedLargeFileReader(file))
 
     def dump(self, obj, file):
         self._write(pickle.dumps(obj, protocol=4), file)

--- a/gokart/object_storage.py
+++ b/gokart/object_storage.py
@@ -10,11 +10,8 @@ from gokart.s3_zip_client import S3ZipClient
 from gokart.gcs_zip_client import GCSZipClient
 from gokart.zip_client import ZipClient
 
+object_storage_path_prefix = ['s3://', 'gs://']
 
-object_storage_path_prefix = [
-    's3://',
-    'gs://'
-]
 
 class ObjectStorage(object):
     @staticmethod
@@ -23,7 +20,6 @@ class ObjectStorage(object):
             if path.startswith(prefix):
                 return True
         return False
-
 
     @staticmethod
     def get_object_storage_target(path: str, format: Format) -> luigi.Target:
@@ -43,7 +39,6 @@ class ObjectStorage(object):
         else:
             raise
 
-
     @staticmethod
     def get_timestamp(path: str) -> datetime:
         if path.startswith('s3://'):
@@ -57,7 +52,6 @@ class ObjectStorage(object):
         else:
             raise
 
-
     @staticmethod
     def get_zip_client(file_path: str, temporary_directory: str) -> ZipClient:
         if file_path.startswith('s3://'):
@@ -66,7 +60,6 @@ class ObjectStorage(object):
             return GCSZipClient(file_path=file_path, temporary_directory=temporary_directory)
         else:
             raise
-
 
     @staticmethod
     def is_readable_objectstorage_instance(file: object):

--- a/gokart/object_storage.py
+++ b/gokart/object_storage.py
@@ -70,8 +70,4 @@ class ObjectStorage(object):
 
     @staticmethod
     def is_readable_objectstorage_instance(file: object):
-        if isinstance(file, luigi.contrib.s3.ReadableS3File):
-            return True
-        else:
-            # for GCS object
-            return isinstance(file, FileWrapper)
+        return isinstance(file, luigi.contrib.s3.ReadableS3File)

--- a/gokart/object_storage.py
+++ b/gokart/object_storage.py
@@ -62,5 +62,5 @@ class ObjectStorage(object):
             raise
 
     @staticmethod
-    def is_readable_objectstorage_instance(file: object):
-        return isinstance(file, luigi.contrib.s3.ReadableS3File)
+    def is_buffered_reader(file: object):
+        return not isinstance(file, luigi.contrib.s3.ReadableS3File)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import boto3
 import numpy as np
 import pandas as pd
-from gokart.file_processor import _LargeLocalFileReader
+from gokart.file_processor import _ChunkedLargeFileReader
 from moto import mock_s3
 
 from gokart.target import make_target, make_model_target
@@ -26,7 +26,7 @@ class LocalTargetTest(unittest.TestCase):
 
         target = make_target(file_path=file_path, unique_id=None)
         target.dump(obj)
-        with unittest.mock.patch('gokart.file_processor._LargeLocalFileReader', wraps=_LargeLocalFileReader) as monkey:
+        with unittest.mock.patch('gokart.file_processor._ChunkedLargeFileReader', wraps=_ChunkedLargeFileReader) as monkey:
             loaded = target.load()
             monkey.assert_called()
 

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import boto3
 import numpy as np
 import pandas as pd
+from gokart.file_processor import _LargeLocalFileReader
 from moto import mock_s3
 
 from gokart.target import make_target, make_model_target
@@ -25,7 +26,9 @@ class LocalTargetTest(unittest.TestCase):
 
         target = make_target(file_path=file_path, unique_id=None)
         target.dump(obj)
-        loaded = target.load()
+        with unittest.mock.patch('gokart.file_processor._LargeLocalFileReader', wraps=_LargeLocalFileReader) as monkey:
+            loaded = target.load()
+            monkey.assert_called()
 
         self.assertEqual(loaded, obj)
 
@@ -169,8 +172,10 @@ class ModelTargetTest(unittest.TestCase):
         obj = 1
         file_path = os.path.join(_get_temporary_directory(), 'test.zip')
 
-        target = make_model_target(
-            file_path=file_path, temporary_directory=_get_temporary_directory(), save_function=self._save_function, load_function=self._load_function)
+        target = make_model_target(file_path=file_path,
+                                   temporary_directory=_get_temporary_directory(),
+                                   save_function=self._save_function,
+                                   load_function=self._load_function)
 
         target.dump(obj)
         loaded = target.load()
@@ -185,8 +190,10 @@ class ModelTargetTest(unittest.TestCase):
         obj = 1
         file_path = os.path.join('s3://test/', 'test.zip')
 
-        target = make_model_target(
-            file_path=file_path, temporary_directory=_get_temporary_directory(), save_function=self._save_function, load_function=self._load_function)
+        target = make_model_target(file_path=file_path,
+                                   temporary_directory=_get_temporary_directory(),
+                                   save_function=self._save_function,
+                                   load_function=self._load_function)
 
         target.dump(obj)
         loaded = target.load()


### PR DESCRIPTION
# Problem
Since https://github.com/m3dev/gokart/pull/80, _LargeLocalFileReader has never been used.
Because ObjectStorage. is_readable_objectstorage_instance is the flag to use _LargeLocalFileReader or not.

This problem is only appears when loading files larger than 4GB on Mac.
https://stackoverflow.com/questions/31468117/python-3-can-pickle-handle-byte-objects-larger-than-4gb 

# Workaround
I have tested that GCS client has ability to read files with chunk.
So I have changed `ObjectStorage. is_readable_objectstorage_instance` only to  prevent S3 files from using `_LargeLocalFileReader`