### PR TITLE
make log simple

### DIFF
--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -58,8 +58,8 @@ class PickleFileProcessor(FileProcessor):
         return luigi.format.Nop
 
     def load(self, file):
-        # if ObjectStorage.is_readable_objectstorage_instance(file):
-        #     return pickle.loads(file.read())
+        if ObjectStorage.is_readable_objectstorage_instance(file):
+            return pickle.loads(file.read())
         return pickle.load(_LargeLocalFileReader(file))
 
     def dump(self, obj, file):

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -58,8 +58,8 @@ class PickleFileProcessor(FileProcessor):
         return luigi.format.Nop
 
     def load(self, file):
-        if ObjectStorage.is_readable_objectstorage_instance(file):
-            return pickle.loads(file.read())
+        # if ObjectStorage.is_readable_objectstorage_instance(file):
+        #     return pickle.loads(file.read())
         return pickle.load(_LargeLocalFileReader(file))
 
     def dump(self, obj, file):

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -8,6 +8,7 @@ import pandas as pd
 from luigi.util import inherits
 
 import gokart
+from gokart.parameter import TaskInstanceParameter, ListTaskInstanceParameter
 from gokart.file_processor import XmlFileProcessor
 from gokart.target import TargetOnKart, SingleFileTarget, ModelTarget
 
@@ -304,6 +305,22 @@ class TaskTest(unittest.TestCase):
 
         with_task = _WithTaskInstanceParameter(a_task=without_task)
         self.assertEqual(with_task.requires()['a_task'], without_task)
+
+    def test_repr(self):
+        class _SubTask(gokart.TaskOnKart):
+            task_namespace = __name__
+
+        class _Task(gokart.TaskOnKart):
+            task_namespace = __name__
+            int_param = luigi.IntParameter()
+            task_param = TaskInstanceParameter()
+            list_task_param = ListTaskInstanceParameter()
+
+        task = _Task(int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
+        sub_task_id = _SubTask().make_unique_id()
+        expected = f'test_task_on_kart._Task(int_param=1, task_param=test_task_on_kart._SubTask({sub_task_id}), ' \
+            f'list_task_param=[test_task_on_kart._SubTask({sub_task_id}), test_task_on_kart._SubTask({sub_task_id})])'
+        self.assertEqual(expected, str(task))
 
 
 if __name__ == '__main__':

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -318,7 +318,7 @@ class TaskTest(unittest.TestCase):
 
         task = _Task(int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
         sub_task_id = _SubTask().make_unique_id()
-        expected = f'test_task_on_kart._Task(int_param=1, task_param=test_task_on_kart._SubTask({sub_task_id}), ' \
+        expected = f'{__name__}._Task(int_param=1, task_param=test_task_on_kart._SubTask({sub_task_id}), ' \
             f'list_task_param=[test_task_on_kart._SubTask({sub_task_id}), test_task_on_kart._SubTask({sub_task_id})])'
         self.assertEqual(expected, str(task))
 

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -318,8 +318,8 @@ class TaskTest(unittest.TestCase):
 
         task = _Task(int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
         sub_task_id = _SubTask().make_unique_id()
-        expected = f'{__name__}._Task(int_param=1, task_param=test_task_on_kart._SubTask({sub_task_id}), ' \
-            f'list_task_param=[test_task_on_kart._SubTask({sub_task_id}), test_task_on_kart._SubTask({sub_task_id})])'
+        expected = f'{__name__}._Task(int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
+            f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'
         self.assertEqual(expected, str(task))
 
 


### PR DESCRIPTION
`TaskInstanceParameter` generates a long task representation in logging. So this PR make it shorter and readable. 

In this version, `TaskInstanceParameter` generates 
```
test_task_on_kart._Task(int_param=1, task_param=test_task_on_kart._SubTask(b31b539ec58343680eab86e7e5d39c56), list_task_param=[test_task_on_kart._SubTask(b31b539ec58343680eab86e7e5d39c56), test_task_on_kart._SubTask(b31b539ec58343680eab86e7e5d39c56)])
```
