### PR TITLE
Add config of setting make tree info for slack notification

### DIFF
--- a/gokart/run.py
+++ b/gokart/run.py
@@ -99,7 +99,7 @@ def _try_to_send_event_summary_to_slack(slack_api: Optional[gokart.slack.SlackAP
         os.linesep,
     ])
     if options.send_tree_info:
-        content += os.linesep.join(['==== Tree Info ====', tree_info])
+        content = os.linesep.join([content, '==== Tree Info ====', tree_info])
     slack_api.send_snippet(comment=comment, title='event.txt', content=content)
 
 

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -89,7 +89,7 @@ def _try_to_send_event_summary_to_slack(slack_api: Optional[gokart.slack.SlackAP
     options = gokart.slack.SlackConfig()
     with CmdlineParser.global_instance(cmdline_args) as cp:
         task = cp.get_task_obj()
-        tree_info = gokart.make_tree_info(task, details=True) if options.send_tree_info else ''
+        tree_info = gokart.make_tree_info(task, details=True) if options.send_tree_info else 'Please add SlackConfig.send_tree_info to include tree-info'
         task_name = type(task).__name__
 
     comment = f'Report of {task_name}' + os.linesep + event_aggregator.get_summary()
@@ -97,9 +97,9 @@ def _try_to_send_event_summary_to_slack(slack_api: Optional[gokart.slack.SlackAP
         '===== Event List ====',
         event_aggregator.get_event_list(),
         os.linesep,
+        '==== Tree Info ====',
+        tree_info
     ])
-    if options.send_tree_info:
-        content = os.linesep.join([content, '==== Tree Info ====', tree_info])
     slack_api.send_snippet(comment=comment, title='event.txt', content=content)
 
 

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -86,9 +86,10 @@ def _try_to_send_event_summary_to_slack(slack_api: Optional[gokart.slack.SlackAP
     if slack_api is None:
         # do nothing
         return
+    options = gokart.slack.SlackConfig()
     with CmdlineParser.global_instance(cmdline_args) as cp:
         task = cp.get_task_obj()
-        tree_info = gokart.make_tree_info(task, details=True)
+        tree_info = gokart.make_tree_info(task, details=True) if options.send_tree_info else ''
         task_name = type(task).__name__
 
     comment = f'Report of {task_name}' + os.linesep + event_aggregator.get_summary()
@@ -96,9 +97,9 @@ def _try_to_send_event_summary_to_slack(slack_api: Optional[gokart.slack.SlackAP
         '===== Event List ====',
         event_aggregator.get_event_list(),
         os.linesep,
-        '==== Tree Info ====',
-        tree_info,
     ])
+    if options.send_tree_info:
+        content += os.linesep.join(['==== Tree Info ====', tree_info])
     slack_api.send_snippet(comment=comment, title='event.txt', content=content)
 
 

--- a/gokart/slack/slack_config.py
+++ b/gokart/slack/slack_config.py
@@ -7,4 +7,4 @@ class SlackConfig(luigi.Config):
     to_user = luigi.Parameter(default='', description='Optional; user name who is supposed to be mentioned.')
     send_tree_info = luigi.BoolParameter(default=True,
                                          description='When this option is true, the dependency tree of tasks is included in send messeage.'
-                                                     'When notification takes long times, it is recommended to set false to this option.')
+                                                     'It is recommended to set false to this option when notification takes long time.')

--- a/gokart/slack/slack_config.py
+++ b/gokart/slack/slack_config.py
@@ -5,6 +5,6 @@ class SlackConfig(luigi.Config):
     token_name = luigi.Parameter(default='SLACK_TOKEN', description='slack token environment variable.')
     channel = luigi.Parameter(default='', description='channel name for notification.')
     to_user = luigi.Parameter(default='', description='Optional; user name who is supposed to be mentioned.')
-    send_tree_info = luigi.BoolParameter(default=True,
+    send_tree_info = luigi.BoolParameter(default=False,
                                          description='When this option is true, the dependency tree of tasks is included in send messeage.'
                                                      'It is recommended to set false to this option when notification takes long time.')

--- a/gokart/slack/slack_config.py
+++ b/gokart/slack/slack_config.py
@@ -3,8 +3,8 @@ import luigi
 
 class SlackConfig(luigi.Config):
     token_name = luigi.Parameter(default='SLACK_TOKEN', description='slack token environment variable.')
-    channel = luigi.Parameter(default='', description='channel name for notification.')
-    to_user = luigi.Parameter(default='', description='Optional; user name who is supposed to be mentioned.')
-    send_tree_info = luigi.BoolParameter(default=False,
+    channel = luigi.Parameter(default='', significant=False, description='channel name for notification.')
+    to_user = luigi.Parameter(default='', significant=False, description='Optional; user name who is supposed to be mentioned.')
+    send_tree_info = luigi.BoolParameter(default=False, significant=False,
                                          description='When this option is true, the dependency tree of tasks is included in send messeage.'
                                                      'It is recommended to set false to this option when notification takes long time.')

--- a/gokart/slack/slack_config.py
+++ b/gokart/slack/slack_config.py
@@ -5,3 +5,6 @@ class SlackConfig(luigi.Config):
     token_name = luigi.Parameter(default='SLACK_TOKEN', description='slack token environment variable.')
     channel = luigi.Parameter(default='', description='channel name for notification.')
     to_user = luigi.Parameter(default='', description='Optional; user name who is supposed to be mentioned.')
+    send_tree_info = luigi.BoolParameter(default=True,
+                                         description='When this option is true, the dependency tree of tasks is included in send messeage.'
+                                                     'When notification takes long times, it is recommended to set false to this option.')

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -64,8 +64,7 @@ class RunTest(unittest.TestCase):
         cmdline_args = [f'{__name__}._DummyTask', '--param', 'test']
         with patch('gokart.slack.SlackConfig.send_tree_info', True):
             _try_to_send_event_summary_to_slack(slack_api_mock, event_aggregator_mock, cmdline_args)
-        expects = os.linesep.join(['===== Event List ====', event_aggregator_mock.get_event_list(), os.linesep])\
-            + os.linesep.join(['==== Tree Info ====', 'tree'])
+        expects = os.linesep.join(['===== Event List ====', event_aggregator_mock.get_event_list(), os.linesep, '==== Tree Info ====', 'tree'])
 
         results = self.output
         self.assertEqual(expects, results)

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -1,11 +1,14 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import luigi
 import luigi.mock
 
+
 import gokart
+from gokart.slack import SlackConfig
+from gokart.run import _try_to_send_event_summary_to_slack
 
 
 class _DummyTask(gokart.TaskOnKart):
@@ -45,6 +48,35 @@ class RunTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             gokart.run()
         self.assertTrue(gokart.make_tree_info(_DummyTask(param='test')), tree_info.output().load())
+
+    @patch('gokart.make_tree_info')
+    def test_try_to_send_event_summary_to_slack(self, make_tree_info_mock: MagicMock):
+        event_aggregator_mock = MagicMock()
+        event_aggregator_mock.get_summury.return_value = f'{__name__}._DummyTask'
+        event_aggregator_mock.get_event_list.return_value = f'{__name__}._DummyTask:[]'
+        make_tree_info_mock.return_value = 'tree'
+
+        def get_content(content: str, **kwargs):
+            self.output = content
+        slack_api_mock = MagicMock()
+        slack_api_mock.send_snippet.side_effect = get_content
+
+        cmdline_args = [f'{__name__}._DummyTask', '--param', 'test']
+        with patch('gokart.slack.SlackConfig.send_tree_info', True):
+            _try_to_send_event_summary_to_slack(slack_api_mock, event_aggregator_mock, cmdline_args)
+        expects = os.linesep.join(['===== Event List ====', event_aggregator_mock.get_event_list(), os.linesep])\
+            + os.linesep.join(['==== Tree Info ====', 'tree'])
+
+        results = self.output
+        self.assertEqual(expects, results)
+
+        cmdline_args = [f'{__name__}._DummyTask', '--param', 'test']
+        with patch('gokart.slack.SlackConfig.send_tree_info', False):
+            _try_to_send_event_summary_to_slack(slack_api_mock, event_aggregator_mock, cmdline_args)
+        expects = os.linesep.join(['===== Event List ====', event_aggregator_mock.get_event_list(), os.linesep])
+
+        results = self.output
+        self.assertEqual(expects, results)
 
 
 if __name__ == '__main__':

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -72,7 +72,12 @@ class RunTest(unittest.TestCase):
         cmdline_args = [f'{__name__}._DummyTask', '--param', 'test']
         with patch('gokart.slack.SlackConfig.send_tree_info', False):
             _try_to_send_event_summary_to_slack(slack_api_mock, event_aggregator_mock, cmdline_args)
-        expects = os.linesep.join(['===== Event List ====', event_aggregator_mock.get_event_list(), os.linesep])
+        expects = os.linesep.join([
+            '===== Event List ====',
+            event_aggregator_mock.get_event_list(),
+            os.linesep,
+            '==== Tree Info ====',
+            'Please add SlackConfig.send_tree_info to include tree-info'])
 
         results = self.output
         self.assertEqual(expects, results)


### PR DESCRIPTION
I would like to add config to set making dependency tree information of gokart tasks for Slack notification.
This processing sometimes take long time to make dependency tree information.
Specifically, the larger the number of dependency tasks become, the longer the time to make this information is taken.
Therefore, I add the option to select which the tree information is sent or not to Slack notification configuration.