### PR TITLE
Feature Request: BoolParameter which must be explicitly specified  value

### DIFF
--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -38,3 +38,11 @@ class ListTaskInstanceParameter(luigi.Parameter):
 
     def serialize(self, x):
         return json.dumps(x, cls=_TaskInstanceEncoder)
+
+
+class ExplicitBoolParameter(luigi.BoolParameter):
+    def __init__(self, *args, **kwargs):
+        luigi.Parameter.__init__(self, *args, **kwargs)
+
+    def _parser_kwargs(self, *args, **kwargs):
+        return luigi.Parameter._parser_kwargs(*args, *kwargs)

--- a/test/test_explicit_bool_parameter.py
+++ b/test/test_explicit_bool_parameter.py
@@ -1,0 +1,63 @@
+import unittest
+import argparse
+from unittest.mock import patch
+
+import luigi
+import luigi.mock
+from luigi.cmdline_parser import CmdlineParser
+
+import gokart
+
+
+def run_locally(args):
+    temp = CmdlineParser._instance
+    try:
+        CmdlineParser._instance = None
+        run_exit_status = luigi.run(['--local-scheduler', '--no-lock'] + args)
+    finally:
+        CmdlineParser._instance = temp
+    return run_exit_status
+
+
+class WithDefaultTrue(gokart.TaskOnKart):
+    param = gokart.parameter.ExplicitBoolParameter(default=True)
+
+
+class WithDefaultFalse(gokart.TaskOnKart):
+    param = gokart.parameter.ExplicitBoolParameter(default=False)
+
+
+class ExplicitParsing(gokart.TaskOnKart):
+    param = gokart.parameter.ExplicitBoolParameter()
+
+    def run(self):
+        ExplicitParsing._param = self.param
+
+
+class TestExplicitBoolParameter(unittest.TestCase):
+    def test_bool_default(self):
+        self.assertTrue(WithDefaultTrue().param)
+        self.assertFalse(WithDefaultFalse().param)
+
+    def test_parse_param(self):
+        run_locally(['ExplicitParsing', '--param', 'true'])
+        self.assertTrue(ExplicitParsing._param)
+        run_locally(['ExplicitParsing', '--param', 'false'])
+        self.assertFalse(ExplicitParsing._param)
+        run_locally(['ExplicitParsing', '--param', 'True'])
+        self.assertTrue(ExplicitParsing._param)
+        run_locally(['ExplicitParsing', '--param', 'False'])
+        self.assertFalse(ExplicitParsing._param)
+
+    def test_missing_parameter(self):
+        with self.assertRaises(luigi.parameter.MissingParameterException):
+            run_locally(['ExplicitParsing'])
+
+    def test_value_error(self):
+        with self.assertRaises(ValueError):
+            run_locally(['ExplicitParsing', '--param', 'Foo'])
+
+    def test_expected_one_argment_error(self):
+        # argparse throw "expected one argument" error
+        with self.assertRaises(SystemExit):
+            run_locally(['ExplicitParsing', '--param'])


### PR DESCRIPTION
`luigi.BoolParameter` already has "explicit parsing" feature, but also still has implicit behavior like follows.

```shell
$ python main.py Task --param
# param will be set as True
$ python main.py Task
# param will be set as False
```

I think my PR feature is not "must-have" for Luigi, but it's "good-to-have" feature for gokart.