### PR TITLE
Change gokart.gcs_config.GCSConfig's behaviour as a singleton

### DIFF
--- a/test/test_gcs_config.py
+++ b/test/test_gcs_config.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock, mock_open
 from gokart.gcs_config import GCSConfig
 
 
-class TestGcfConfig(unittest.TestCase):
+class TestGCSConfig(unittest.TestCase):
     def test_get_gcs_client_without_gcs_credential_name(self):
         mock = MagicMock()
         discover_path = 'discover_cache.json'
@@ -15,8 +15,8 @@ class TestGcfConfig(unittest.TestCase):
             f.write('{}')
         with patch('luigi.contrib.gcs.GCSClient', mock):
             with patch('fcntl.flock'):
-               GCSConfig(gcs_credential_name='env_name', discover_cache_local_path=discover_path).get_gcs_client()
-               self.assertEqual(dict(oauth_credentials=None, descriptor='{}'), mock.call_args[1])
+                GCSConfig(gcs_credential_name='env_name', discover_cache_local_path=discover_path)._get_gcs_client()
+                self.assertEqual(dict(oauth_credentials=None, descriptor='{}'), mock.call_args[1])
 
     def test_get_gcs_client_with_file_path(self):
         mock = MagicMock()
@@ -29,8 +29,8 @@ class TestGcfConfig(unittest.TestCase):
         with patch('luigi.contrib.gcs.GCSClient'):
             with patch('google.oauth2.service_account.Credentials.from_service_account_file', mock):
                 with patch('os.path.isfile', return_value=True):
-                   GCSConfig(gcs_credential_name='env_name', discover_cache_local_path=discover_path).get_gcs_client()
-                   self.assertEqual(file_path, mock.call_args[0][0])
+                    GCSConfig(gcs_credential_name='env_name', discover_cache_local_path=discover_path)._get_gcs_client()
+                    self.assertEqual(file_path, mock.call_args[0][0])
 
     def test_get_gcs_client_with_json(self):
         mock = MagicMock()
@@ -42,5 +42,5 @@ class TestGcfConfig(unittest.TestCase):
             f.write('{}')
         with patch('luigi.contrib.gcs.GCSClient'):
             with patch('google.oauth2.service_account.Credentials.from_service_account_info', mock):
-               GCSConfig(gcs_credential_name='env_name', discover_cache_local_path=discover_path).get_gcs_client()
-               self.assertEqual(dict(test=1), mock.call_args[0][0])
+                GCSConfig(gcs_credential_name='env_name', discover_cache_local_path=discover_path)._get_gcs_client()
+                self.assertEqual(dict(test=1), mock.call_args[0][0])


### PR DESCRIPTION
Initializing GCSConfig is a mess process because of 
1. simply time consuming
2. noisy warning when using local default credentials (UserWarning: Your application has authenticated using end user credentials  ...)

We actually need to initialize GCSConfig just once in a whole process. So I've changed GCSConfig's behaviour as like singleton pattern.