### PR TITLE
Fix returning instance parameter at requires

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -197,7 +197,7 @@ class TaskOnKart(luigi.Task):
         data = _flatten_recursively(self.load(target=target))
 
         required_columns = required_columns or set()
-        if data.empty and len(data.index) == 0 and len(data.columns) == 0:
+        if data.empty and len(data.index) == 0 and len(required_columns - set(data.columns)) > 0 == 0:
             return pd.DataFrame(columns=required_columns)
         assert required_columns.issubset(set(data.columns)), f'data must have columns {required_columns}, but actually have only {data.columns}.'
         if drop_columns:

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -186,19 +186,18 @@ class TaskOnKart(luigi.Task):
 
         return _load(self._get_input_targets(target))
 
-    def load_data_frame(self,
-                        target: Union[None, str, TargetOnKart] = None,
-                        required_columns: Optional[Set[str]] = None,
+    def load_data_frame(self, target: Union[None, str, TargetOnKart] = None, required_columns: Optional[Set[str]] = None,
                         drop_columns: bool = False) -> pd.DataFrame:
         def _flatten_recursively(dfs):
             if isinstance(dfs, list):
                 return pd.concat([_flatten_recursively(df) for df in dfs])
             else:
                 return dfs
+
         data = _flatten_recursively(self.load(target=target))
 
         required_columns = required_columns or set()
-        if data.empty and len(data.index) == 0:
+        if data.empty and len(data.index) == 0 and len(data.columns) == 0:
             return pd.DataFrame(columns=required_columns)
         assert required_columns.issubset(set(data.columns)), f'data must have columns {required_columns}, but actually have only {data.columns}.'
         if drop_columns:

--- a/test/test_restore_task_by_id.py
+++ b/test/test_restore_task_by_id.py
@@ -11,6 +11,9 @@ class _SubDummyTask(gokart.TaskOnKart):
     task_namespace = __name__
     param = luigi.IntParameter()
 
+    def run(self):
+        self.dump('test')
+
 
 class _DummyTask(gokart.TaskOnKart):
     task_namespace = __name__
@@ -33,7 +36,7 @@ class RestoreTaskByIDTest(unittest.TestCase):
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: luigi.mock.MockTarget(path, **kwargs))
     def test(self):
         task = _DummyTask(sub_task=_SubDummyTask(param=10))
-        luigi.build([task], local_scheduler=True, log_level="CRITICAL")
+        luigi.build([task], local_scheduler=True, log_level="INFO")
 
         unique_id = task.make_unique_id()
         restored = _DummyTask.restore(unique_id)

--- a/test/test_restore_task_by_id.py
+++ b/test/test_restore_task_by_id.py
@@ -19,9 +19,6 @@ class _DummyTask(gokart.TaskOnKart):
     task_namespace = __name__
     sub_task = gokart.TaskInstanceParameter()
 
-    def requires(self):
-        return []
-
     def output(self):
         return self.make_target('test.txt')
 

--- a/test/test_restore_task_by_id.py
+++ b/test/test_restore_task_by_id.py
@@ -36,7 +36,7 @@ class RestoreTaskByIDTest(unittest.TestCase):
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: luigi.mock.MockTarget(path, **kwargs))
     def test(self):
         task = _DummyTask(sub_task=_SubDummyTask(param=10))
-        luigi.build([task], local_scheduler=True, log_level="INFO")
+        luigi.build([task], local_scheduler=True, log_level="CRITICAL")
 
         unique_id = task.make_unique_id()
         restored = _DummyTask.restore(unique_id)

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -273,10 +273,8 @@ class TaskTest(unittest.TestCase):
         mock_cmdline.return_value = luigi.cmdline_parser.CmdlineParser(['DummyTaskAddConfiguration'])
         self.assertEqual(DummyTaskAddConfiguration().aa, 3)
 
-        mock_cmdline.return_value = luigi.cmdline_parser.CmdlineParser(
-            ['DummyTaskAddConfiguration', '--DummyTaskAddConfiguration-aa', '2'])
+        mock_cmdline.return_value = luigi.cmdline_parser.CmdlineParser(['DummyTaskAddConfiguration', '--DummyTaskAddConfiguration-aa', '2'])
         self.assertEqual(DummyTaskAddConfiguration().aa, 2)
-
 
     def test_load_list_of_list_pandas(self):
         task = _DummyTask()
@@ -295,12 +293,21 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(1, df.shape[0])
         self.assertSetEqual({'a', 'c'}, set(df.columns))
 
+    def test_load_data_frame_empty_input(self):
+        task = _DummyTask()
+        task.load = MagicMock(return_value=pd.DataFrame(dict(a=[], b=[], c=[])))
+
+        df = task.load_data_frame(required_columns={'a', 'c'})
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(0, df.shape[0])
+        self.assertSetEqual({'a', 'b', 'c'}, set(df.columns))
+
     def test_load_index_only_dataframe(self):
         task = _DummyTask()
         task.load = MagicMock(return_value=pd.DataFrame(index=range(3)))
 
         # connnot load index only frame with required_columns
-        self.assertRaises(AssertionError, lambda : task.load_data_frame(required_columns={'a', 'c'}))
+        self.assertRaises(AssertionError, lambda: task.load_data_frame(required_columns={'a', 'c'}))
 
         df: pd.DataFrame = task.load_data_frame()
         self.assertIsInstance(df, pd.DataFrame)


### PR DESCRIPTION
[What is this PR?]
TaskInstanceParameters will be automatically added to `requires()`'s return.

[Why?]
At the current code, TaskInstanceParameters will not be returned automatically when `requires()` is overrided at task.

Please review.