### PR TITLE
Feather Format FileProcessor

### DIFF
--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -193,6 +193,23 @@ class ParquetFileProcessor(FileProcessor):
         obj.to_parquet(file.name, index=False, compression=self._compression)
 
 
+class FeatherFileProcessor(FileProcessor):
+    def __init__(self):
+        super(FeatherFileProcessor, self).__init__()
+
+    def format(self):
+        return None
+
+    def load(self, file):
+        return pd.read_feather(file.name)
+
+    def dump(self, obj, file):
+        assert isinstance(obj, (pd.DataFrame)), \
+            f'requires pd.DataFrame, but {type(obj)} is passed.'
+        # to_feather supports "bynary" file-like object, but file variable is text
+        obj.to_feather(file.name)
+
+
 def make_file_processor(file_path: str) -> FileProcessor:
     extension2processor = {
         '.txt': TextFileProcessor(),
@@ -203,7 +220,8 @@ def make_file_processor(file_path: str) -> FileProcessor:
         '.json': JsonFileProcessor(),
         '.xml': XmlFileProcessor(),
         '.npz': NpzFileProcessor(),
-        '.parquet': ParquetFileProcessor(compression='gzip')
+        '.parquet': ParquetFileProcessor(compression='gzip'),
+        '.feather': FeatherFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -91,6 +91,16 @@ class LocalTargetTest(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, obj)
 
+    def test_save_and_load_feather(self):
+        obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))
+        file_path = os.path.join(_get_temporary_directory(), 'test.feather')
+
+        target = make_target(file_path=file_path, unique_id=None)
+        target.dump(obj)
+        loaded = target.load()
+
+        pd.testing.assert_frame_equal(loaded, obj)
+
     def test_last_modified_time(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))
         file_path = os.path.join(_get_temporary_directory(), 'test.csv')


### PR DESCRIPTION
Feather file format is very useful for extremely huge size dataframe.
I've measured i/o speed and file size, so please consider whether or not to support it.

https://github.com/wesm/feather

I experiment with following dataframe for estimating read/write time and filesize.
```
5000 rows x 150000 columns
memory usage: 4.9 GB
```

|                  |   write ( sec ) |    read ( sec ) |  filesize   |
|:-----------------|--------:|--------:|:------------|
| pickle           |    26.5 |    18.9 | 5.03 GB     |
| feather          |    16.7 |     9.7 | 115 MB      |
| parquet          |    40.3 |   151   | 123 MB      |
| large_data_frame |   128   |    51.4 | 107 MB      |
