### PR TITLE
Handle task cache collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,34 @@ def requires(self):
 def run(self):
     data = self.load_data_frame(required_columns={'id', 'name'})  
 ```
+
+## Advanced
+### Using task lock
+Task lock is implemented to prevent task cahche collision.
+(Originally, task cache collision may occur when same task with same parameters run at different applications parallelly.) 
+
+1. Set up a redis server at somewhere accessible from gokart/luigi jobs.
+
+    Following will run redis at your localhost.
+
+    ```bash
+    $ redis-server
+    ```
+
+2. Set redis server hostname and port number as parameters to gokart.TaskOnKart().
+
+    You can set it by adding `--redis-host=[your-redis-localhost] --redis-port=[redis-port-number]` options to gokart python script.
+
+    e.g.
+    ```bash
+    
+    python main.py sample.SomeTask --local-scheduler --redis-host=localhost --redis-port=6379
+    ```
+
+    Alternatively, you may set parameters at config file.
+
+    ```conf.ini
+    [TaskOnKart]
+    redis_host=localhost
+    redis_port=6379
+    ```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ def run(self):
 
 ## Advanced
 ### Using task lock
+#### Require
+You need to install (redis)[https://redis.io/topics/quickstart] for this advanced function.
+
+#### Description
 Task lock is implemented to prevent task cahche collision.
 (Originally, task cache collision may occur when same task with same parameters run at different applications parallelly.) 
 

--- a/gokart/redis_lock.py
+++ b/gokart/redis_lock.py
@@ -1,6 +1,6 @@
 import os
 from logging import getLogger
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import redis
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -9,9 +9,9 @@ logger = getLogger(__name__)
 
 
 class RedisParams(NamedTuple):
-    redis_host: str
-    redis_port: str
-    redis_key: str
+    redis_host: Optional[str]
+    redis_port: Optional[str]
+    redis_key: Optional[str]
     should_redis_lock: bool
 
 

--- a/gokart/redis_lock.py
+++ b/gokart/redis_lock.py
@@ -1,0 +1,60 @@
+import os
+from logging import INFO, getLogger
+from typing import NamedTuple
+
+import redis
+from apscheduler.schedulers.background import BackgroundScheduler
+
+logger = getLogger(__name__)
+logger.setLevel(INFO)
+
+
+class RedisParams(NamedTuple):
+    redis_host: str
+    redis_port: str
+    redis_key: str
+    should_redis_lock: bool
+
+
+def with_lock(func, redis_params: RedisParams):
+    if not redis_params.should_redis_lock:
+        return func
+
+    def wrapper(*args, **kwargs):
+        redis_client = redis.Redis(host=redis_params.redis_host, port=redis_params.redis_port)
+        redis_lock = redis.lock.Lock(redis=redis_client, name=redis_params.redis_key, timeout=15, blocking=True, thread_local=False)
+        redis_lock.acquire()
+
+        def extend_lock():
+            redis_lock.extend(additional_time=15, replace_ttl=True)
+
+        scheduler = BackgroundScheduler()
+        scheduler.add_job(extend_lock, 'interval', seconds=10)
+        scheduler.start()
+
+        try:
+            logger.info(f'Task lock of {redis_params.redis_key} {func} locked.')
+            result = func(*args, **kwargs)
+            redis_lock.release()
+            logger.info(f'Task lock of {redis_params.redis_key} {func} released.')
+            scheduler.shutdown()
+            return result
+        except BaseException as e:
+            redis_lock.release()
+            logger.info(f'Task lock of {redis_params.redis_key} {func} released with BaseException.')
+            scheduler.shutdown()
+            raise e
+
+    return wrapper
+
+
+def make_redis_key(file_path: str, unique_id: str):
+    basename_without_ext = os.path.splitext(os.path.basename(file_path))[0]
+    return f'{basename_without_ext}_{unique_id}'
+
+
+def make_redis_params(file_path: str, unique_id: str, redis_host: str, redis_port: str):
+    redis_key = make_redis_key(file_path, unique_id)
+    should_redis_lock = redis_host is not None and redis_port is not None
+    redis_params = RedisParams(redis_host=redis_host, redis_port=redis_port, redis_key=redis_key, should_redis_lock=should_redis_lock)
+    return redis_params

--- a/gokart/redis_lock.py
+++ b/gokart/redis_lock.py
@@ -9,10 +9,10 @@ logger = getLogger(__name__)
 
 
 class RedisParams(NamedTuple):
-    redis_host: Optional[str]
-    redis_port: Optional[str]
-    redis_key: Optional[str]
-    should_redis_lock: bool
+    redis_host: Optional[str] = None
+    redis_port: Optional[str] = None
+    redis_key: Optional[str] = None
+    should_redis_lock: bool = False
 
 
 def with_lock(func, redis_params: RedisParams):

--- a/gokart/redis_lock.py
+++ b/gokart/redis_lock.py
@@ -1,12 +1,11 @@
 import os
-from logging import INFO, getLogger
+from logging import getLogger
 from typing import NamedTuple
 
 import redis
 from apscheduler.schedulers.background import BackgroundScheduler
 
 logger = getLogger(__name__)
-logger.setLevel(INFO)
 
 
 class RedisParams(NamedTuple):
@@ -33,15 +32,15 @@ def with_lock(func, redis_params: RedisParams):
         scheduler.start()
 
         try:
-            logger.info(f'Task lock of {redis_params.redis_key} {func} locked.')
+            logger.debug(f'Task lock of {redis_params.redis_key} locked.')
             result = func(*args, **kwargs)
             redis_lock.release()
-            logger.info(f'Task lock of {redis_params.redis_key} {func} released.')
+            logger.debug(f'Task lock of {redis_params.redis_key} released.')
             scheduler.shutdown()
             return result
         except BaseException as e:
             redis_lock.release()
-            logger.info(f'Task lock of {redis_params.redis_key} {func} released with BaseException.')
+            logger.debug(f'Task lock of {redis_params.redis_key} released with BaseException.')
             scheduler.shutdown()
             raise e
 

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -41,7 +41,7 @@ class TargetOnKart(luigi.Target):
         return self._path()
 
     def _with_lock(self, func):
-        return with_lock(func=func, redis_param=self.redis_params)
+        return with_lock(func=func, redis_params=self._redis_params)
 
     @abstractmethod
     def _exists(self) -> bool:
@@ -72,6 +72,7 @@ class SingleFileTarget(TargetOnKart):
     def __init__(self, target: luigi.target.FileSystemTarget, processor: FileProcessor, redis_params: RedisParams) -> None:
         self._target = target
         self._processor = processor
+        self._redis_params = redis_params
 
     def _exists(self) -> bool:
         return self._target.exists()
@@ -101,6 +102,7 @@ class ModelTarget(TargetOnKart):
         self._temporary_directory = temporary_directory
         self._save_function = save_function
         self._load_function = load_function
+        self._redis_params = redis_params
 
     def _exists(self) -> bool:
         return self._zip_client.exists()

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -46,6 +46,9 @@ class TargetOnKart(luigi.Target):
     def path(self) -> str:
         return self._path()
 
+    def _with_lock(self, func):
+        return with_lock(func, self.redis_params)
+
     @abstractmethod
     def _exists(self) -> bool:
         pass

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -22,9 +22,9 @@ logger = getLogger(__name__)
 
 
 def _decorate_file_access_functions_with_redis_lock(super, self, redis_params):
-    self._load = with_lock(func=super._load, redis_params=redis_params)
-    self._dump = with_lock(func=super._dump, redis_params=redis_params)
-    self._remove = with_lock(func=super._remove, redis_params=redis_params)
+    self.load = with_lock(func=super.load, redis_params=redis_params)
+    self.dump = with_lock(func=super.dump, redis_params=redis_params)
+    self.remove = with_lock(func=super.remove, redis_params=redis_params)
 
 
 class TargetOnKart(luigi.Target):

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -215,8 +215,9 @@ def make_target(file_path: str,
                 unique_id: Optional[str] = None,
                 processor: Optional[FileProcessor] = None,
                 redis_host: str = None,
-                redis_port: str = None) -> TargetOnKart:
-    redis_params = make_redis_params(file_path=file_path, unique_id=unique_id, redis_host=redis_host, redis_port=redis_port)
+                redis_port: str = None,
+                redis_timeout: int = 180) -> TargetOnKart:
+    redis_params = make_redis_params(file_path=file_path, unique_id=unique_id, redis_host=redis_host, redis_port=redis_port, redis_timeout=redis_timeout)
     file_path = _make_file_path(file_path, unique_id)
     processor = processor or make_file_processor(file_path)
     file_system_target = _make_file_system_target(file_path, processor=processor)
@@ -229,8 +230,9 @@ def make_model_target(file_path: str,
                       load_function,
                       unique_id: Optional[str] = None,
                       redis_host: str = None,
-                      redis_port: str = None) -> TargetOnKart:
-    redis_params = make_redis_params(file_path=file_path, unique_id=unique_id, redis_host=redis_host, redis_port=redis_port)
+                      redis_port: str = None,
+                      redis_timeout: int = 180) -> TargetOnKart:
+    redis_params = make_redis_params(file_path=file_path, unique_id=unique_id, redis_host=redis_host, redis_port=redis_port, redis_timeout=redis_timeout)
     file_path = _make_file_path(file_path, unique_id)
     temporary_directory = os.path.join(temporary_directory, hashlib.md5(file_path.encode()).hexdigest())
     return ModelTarget(file_path=file_path,

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -69,7 +69,12 @@ class TargetOnKart(luigi.Target):
 
 
 class SingleFileTarget(TargetOnKart):
-    def __init__(self, target: luigi.target.FileSystemTarget, processor: FileProcessor, redis_params: RedisParams) -> None:
+    def __init__(
+            self,
+            target: luigi.target.FileSystemTarget,
+            processor: FileProcessor,
+            redis_params: RedisParams = RedisParams(redis_host=None, redis_port=None, redis_key=None, should_redis_lock=False),
+    ) -> None:
         self._target = target
         self._processor = processor
         self._redis_params = redis_params
@@ -97,7 +102,14 @@ class SingleFileTarget(TargetOnKart):
 
 
 class ModelTarget(TargetOnKart):
-    def __init__(self, file_path: str, temporary_directory: str, load_function, save_function, redis_params: RedisParams) -> None:
+    def __init__(
+            self,
+            file_path: str,
+            temporary_directory: str,
+            load_function,
+            save_function,
+            redis_params: RedisParams = RedisParams(redis_host=None, redis_port=None, redis_key=None, should_redis_lock=False),
+    ) -> None:
         self._zip_client = make_zip_client(file_path, temporary_directory)
         self._temporary_directory = temporary_directory
         self._save_function = save_function

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -21,10 +21,10 @@ from gokart.redis_lock import RedisParams, make_redis_params, with_lock
 logger = getLogger(__name__)
 
 
-def _decorate_file_access_functions_with_redis_lock(self, redis_params):
-    self._load = with_lock(func=self._load, redis_params=redis_params)
-    self._dump = with_lock(func=self._dump, redis_params=redis_params)
-    self._remove = with_lock(func=self._remove, redis_params=redis_params)
+def _decorate_file_access_functions_with_redis_lock(super, self, redis_params):
+    self._load = with_lock(func=super._load, redis_params=redis_params)
+    self._dump = with_lock(func=super._dump, redis_params=redis_params)
+    self._remove = with_lock(func=super._remove, redis_params=redis_params)
 
 
 class TargetOnKart(luigi.Target):
@@ -75,7 +75,7 @@ class SingleFileTarget(TargetOnKart):
     def __init__(self, target: luigi.target.FileSystemTarget, processor: FileProcessor, redis_params: RedisParams) -> None:
         self._target = target
         self._processor = processor
-        _decorate_file_access_functions_with_redis_lock(self=self, redis_params=redis_params)
+        _decorate_file_access_functions_with_redis_lock(super=super(SingleFileTarget, self), self=self, redis_params=redis_params)
 
     def _exists(self) -> bool:
         return self._target.exists()
@@ -106,7 +106,7 @@ class ModelTarget(TargetOnKart):
         self._save_function = save_function
         self._load_function = load_function
 
-        _decorate_file_access_functions_with_redis_lock(self=self, redis_params=redis_params)
+        _decorate_file_access_functions_with_redis_lock(super=super(ModelTarget, self), self=self, redis_params=redis_params)
 
     def _exists(self) -> bool:
         return self._zip_client.exists()

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -197,7 +197,7 @@ class TaskOnKart(luigi.Task):
         data = _flatten_recursively(self.load(target=target))
 
         required_columns = required_columns or set()
-        if data.empty and len(data.index) == 0 and len(data.columns) == 0:
+        if data.empty and len(data.index) == 0 and len(required_columns - set(data.columns)) > 0 == 0:
             return pd.DataFrame(columns=required_columns)
         assert required_columns.issubset(set(data.columns)), f'data must have columns {required_columns}, but actually have only {data.columns}.'
         if drop_columns:

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -186,19 +186,18 @@ class TaskOnKart(luigi.Task):
 
         return _load(self._get_input_targets(target))
 
-    def load_data_frame(self,
-                        target: Union[None, str, TargetOnKart] = None,
-                        required_columns: Optional[Set[str]] = None,
+    def load_data_frame(self, target: Union[None, str, TargetOnKart] = None, required_columns: Optional[Set[str]] = None,
                         drop_columns: bool = False) -> pd.DataFrame:
         def _flatten_recursively(dfs):
             if isinstance(dfs, list):
                 return pd.concat([_flatten_recursively(df) for df in dfs])
             else:
                 return dfs
+
         data = _flatten_recursively(self.load(target=target))
 
         required_columns = required_columns or set()
-        if data.empty and len(data.index) == 0:
+        if data.empty and len(data.index) == 0 and len(data.columns) == 0:
             return pd.DataFrame(columns=required_columns)
         assert required_columns.issubset(set(data.columns)), f'data must have columns {required_columns}, but actually have only {data.columns}.'
         if drop_columns:

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -48,6 +48,9 @@ class TaskOnKart(luigi.Task):
     fix_random_seed_methods = luigi.ListParameter(default=['random.seed', 'numpy.random.seed'], description='Fix random seed method list.', significant=False)
     fix_random_seed_value = luigi.IntParameter(default=None, description='Fix random seed method value.', significant=False)
 
+    redis_host = luigi.Parameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
+    redis_port = luigi.Parameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
+
     def __init__(self, *args, **kwargs):
         self._add_configuration(kwargs, 'TaskOnKart')
         # 'This parameter is dumped into "workspace_directory/log/task_log/" when this task finishes with success.'
@@ -130,7 +133,7 @@ class TaskOnKart(luigi.Task):
     def make_target(self, relative_file_path: str, use_unique_id: bool = True, processor: Optional[FileProcessor] = None) -> TargetOnKart:
         file_path = os.path.join(self.workspace_directory, relative_file_path)
         unique_id = self.make_unique_id() if use_unique_id else None
-        return gokart.target.make_target(file_path=file_path, unique_id=unique_id, processor=processor)
+        return gokart.target.make_target(file_path=file_path, unique_id=unique_id, processor=processor, redis_host=self.redis_host, redis_port=self.redis_port)
 
     def make_large_data_frame_target(self, relative_file_path: str, use_unique_id: bool = True, max_byte=int(2**26)) -> TargetOnKart:
         file_path = os.path.join(self.workspace_directory, relative_file_path)
@@ -139,7 +142,9 @@ class TaskOnKart(luigi.Task):
                                                temporary_directory=self.local_temporary_directory,
                                                unique_id=unique_id,
                                                save_function=gokart.target.LargeDataFrameProcessor(max_byte=max_byte).save,
-                                               load_function=gokart.target.LargeDataFrameProcessor.load)
+                                               load_function=gokart.target.LargeDataFrameProcessor.load,
+                                               redis_host=self.redis_host,
+                                               redis_port=self.redis_port)
 
     def make_model_target(self,
                           relative_file_path: str,
@@ -150,9 +155,9 @@ class TaskOnKart(luigi.Task):
         Make target for models which generate multiple files in saving, e.g. gensim.Word2Vec, Tensorflow, and so on.
 
         :param relative_file_path: A file path to save.
-        :param save_function: A function to save a model. This takes a model object and a file path. 
+        :param save_function: A function to save a model. This takes a model object and a file path.
         :param load_function: A function to load a model. This takes a file path and returns a model object.
-        :param use_unique_id: If this is true, add an unique id to a file base name.  
+        :param use_unique_id: If this is true, add an unique id to a file base name.
         """
         file_path = os.path.join(self.workspace_directory, relative_file_path)
         assert relative_file_path[-3:] == 'zip', f'extension must be zip, but {relative_file_path} is passed.'
@@ -161,7 +166,9 @@ class TaskOnKart(luigi.Task):
                                                temporary_directory=self.local_temporary_directory,
                                                unique_id=unique_id,
                                                save_function=save_function,
-                                               load_function=load_function)
+                                               load_function=load_function,
+                                               redis_host=self.redis_host,
+                                               redis_port=self.redis_port)
 
     def load(self, target: Union[None, str, TargetOnKart] = None) -> Any:
         def _load(targets):
@@ -186,7 +193,9 @@ class TaskOnKart(luigi.Task):
 
         return _load(self._get_input_targets(target))
 
-    def load_data_frame(self, target: Union[None, str, TargetOnKart] = None, required_columns: Optional[Set[str]] = None,
+    def load_data_frame(self,
+                        target: Union[None, str, TargetOnKart] = None,
+                        required_columns: Optional[Set[str]] = None,
                         drop_columns: bool = False) -> pd.DataFrame:
         def _flatten_recursively(dfs):
             if isinstance(dfs, list):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from os import path
 with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-
 install_requires = [
     'luigi',
     'boto3',
@@ -16,7 +15,9 @@ install_requires = [
     'google-auth',
     'pyarrow',
     'uritemplate',
-    'google-api-python-client'
+    'google-api-python-client',
+    'APScheduler',
+    'redis',
 ]
 
 setup(

--- a/test/test_redis_lock.py
+++ b/test/test_redis_lock.py
@@ -1,6 +1,27 @@
+import random
 import unittest
+from unittest.mock import patch
 
-from gokart.redis_lock import RedisParams, make_redis_key, make_redis_params
+from gokart.redis_lock import RedisClient, RedisParams, make_redis_key, make_redis_params
+
+
+class TestRedisClient(unittest.TestCase):
+    @staticmethod
+    def _get_randint(host, port):
+        return random.randint(0, 100000)
+
+    def test_redis_client_is_singleton(self):
+        with patch('redis.Redis') as mock:
+            mock.side_effect = self._get_randint
+
+            redis_client_0_0 = RedisClient(host='host_0', port='123')
+            redis_client_1 = RedisClient(host='host_1', port='123')
+            redis_client_0_1 = RedisClient(host='host_0', port='123')
+
+            self.assertNotEqual(redis_client_0_0, redis_client_1)
+            self.assertEqual(redis_client_0_0, redis_client_0_1)
+
+            self.assertEqual(redis_client_0_0.get_redis_client(), redis_client_0_1.get_redis_client())
 
 
 class TestMakeRedisKey(unittest.TestCase):

--- a/test/test_redis_lock.py
+++ b/test/test_redis_lock.py
@@ -1,0 +1,21 @@
+import unittest
+
+from gokart.redis_lock import RedisParams, make_redis_key, make_redis_params
+
+
+class TestMakeRedisKey(unittest.TestCase):
+    def test_make_redis_key(self):
+        result = make_redis_key(file_path='gs://test_ll/dir/fname.pkl', unique_id='12345')
+        self.assertEqual(result, 'fname_12345')
+
+
+class TestMakeRedisParams(unittest.TestCase):
+    def test_make_redis_params_with_valid_host(self):
+        result = make_redis_params(file_path='gs://aaa.pkl', unique_id='123', redis_host='0.0.0.0', redis_port='12345')
+        expected = RedisParams(redis_host='0.0.0.0', redis_port='12345', redis_key='aaa_123', should_redis_lock=True)
+        self.assertEqual(result, expected)
+
+    def test_make_redis_params_with_no_host(self):
+        result = make_redis_params(file_path='gs://aaa.pkl', unique_id='123', redis_host=None, redis_port='12345')
+        expected = RedisParams(redis_host=None, redis_port='12345', redis_key='aaa_123', should_redis_lock=False)
+        self.assertEqual(result, expected)

--- a/test/test_redis_lock.py
+++ b/test/test_redis_lock.py
@@ -32,11 +32,11 @@ class TestMakeRedisKey(unittest.TestCase):
 
 class TestMakeRedisParams(unittest.TestCase):
     def test_make_redis_params_with_valid_host(self):
-        result = make_redis_params(file_path='gs://aaa.pkl', unique_id='123', redis_host='0.0.0.0', redis_port='12345')
-        expected = RedisParams(redis_host='0.0.0.0', redis_port='12345', redis_key='aaa_123', should_redis_lock=True)
+        result = make_redis_params(file_path='gs://aaa.pkl', unique_id='123', redis_host='0.0.0.0', redis_port='12345', redis_timeout=180)
+        expected = RedisParams(redis_host='0.0.0.0', redis_port='12345', redis_key='aaa_123', should_redis_lock=True, redis_timeout=180)
         self.assertEqual(result, expected)
 
     def test_make_redis_params_with_no_host(self):
-        result = make_redis_params(file_path='gs://aaa.pkl', unique_id='123', redis_host=None, redis_port='12345')
-        expected = RedisParams(redis_host=None, redis_port='12345', redis_key='aaa_123', should_redis_lock=False)
+        result = make_redis_params(file_path='gs://aaa.pkl', unique_id='123', redis_host=None, redis_port='12345', redis_timeout=180)
+        expected = RedisParams(redis_host=None, redis_port='12345', redis_key='aaa_123', should_redis_lock=False, redis_timeout=180)
         self.assertEqual(result, expected)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -7,6 +7,7 @@ import boto3
 import numpy as np
 import pandas as pd
 from gokart.file_processor import _ChunkedLargeFileReader
+from gokart.redis_lock import RedisParams
 from moto import mock_s3
 
 from gokart.target import make_target, make_model_target

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -273,10 +273,8 @@ class TaskTest(unittest.TestCase):
         mock_cmdline.return_value = luigi.cmdline_parser.CmdlineParser(['DummyTaskAddConfiguration'])
         self.assertEqual(DummyTaskAddConfiguration().aa, 3)
 
-        mock_cmdline.return_value = luigi.cmdline_parser.CmdlineParser(
-            ['DummyTaskAddConfiguration', '--DummyTaskAddConfiguration-aa', '2'])
+        mock_cmdline.return_value = luigi.cmdline_parser.CmdlineParser(['DummyTaskAddConfiguration', '--DummyTaskAddConfiguration-aa', '2'])
         self.assertEqual(DummyTaskAddConfiguration().aa, 2)
-
 
     def test_load_list_of_list_pandas(self):
         task = _DummyTask()
@@ -295,12 +293,21 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(1, df.shape[0])
         self.assertSetEqual({'a', 'c'}, set(df.columns))
 
+    def test_load_data_frame_empty_input(self):
+        task = _DummyTask()
+        task.load = MagicMock(return_value=pd.DataFrame(dict(a=[], b=[], c=[])))
+
+        df = task.load_data_frame(required_columns={'a', 'c'})
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(0, df.shape[0])
+        self.assertSetEqual({'a', 'b', 'c'}, set(df.columns))
+
     def test_load_index_only_dataframe(self):
         task = _DummyTask()
         task.load = MagicMock(return_value=pd.DataFrame(index=range(3)))
 
         # connnot load index only frame with required_columns
-        self.assertRaises(AssertionError, lambda : task.load_data_frame(required_columns={'a', 'c'}))
+        self.assertRaises(AssertionError, lambda: task.load_data_frame(required_columns={'a', 'c'}))
 
         df: pd.DataFrame = task.load_data_frame()
         self.assertIsInstance(df, pd.DataFrame)

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -381,7 +381,7 @@ class TaskTest(unittest.TestCase):
 
         task = _Task(int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
         sub_task_id = _SubTask().make_unique_id()
-        expected = f'{__name__}._Task(int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
+        expected = f'{__name__}._Task(redis_timeout=180, int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
             f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'
         self.assertEqual(expected, str(task))
 


### PR DESCRIPTION
[What is this PR?]
- Adding function to handle task cache collision

[Why?]
- When multiple applications run  same task at same workspace simultaneously, task cache may collide.
- example
  - Consider situation with same task AA running at application A and application B.
  - In such case, when one task loads the cache while the other is writing, unexpected error may happen.

[How to overcome the problem?]
- Implement cache file lock using redis
  - When gokart write/load/delete cache file, gokart will ask redis to lock file.
  - When lock is taken by other application, gokart will not run write/load/delete and wait for the lock to be released.


