### PR TITLE
gokart.file_processor.BinaryFileProcessor for png/jpg files

### DIFF
--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -31,6 +31,27 @@ class FileProcessor(object):
         pass
 
 
+class BinaryFileProcessor(FileProcessor):
+    """
+    Pass bytes to this processor
+
+    ```
+    figure_binary = io.BytesIO()
+    plt.savefig(figure_binary)
+    figure_binary.seek(0)
+    BinaryFileProcessor().dump(figure_binary.read())
+    ```
+    """
+    def format(self):
+        return luigi.format.Nop
+
+    def load(self, file):
+        return file.read()
+
+    def dump(self, obj, file):
+        file.write(obj)
+
+
 class _ChunkedLargeFileReader(object):
     def __init__(self, file) -> None:
         self._file = file
@@ -222,6 +243,8 @@ def make_file_processor(file_path: str) -> FileProcessor:
         '.npz': NpzFileProcessor(),
         '.parquet': ParquetFileProcessor(compression='gzip'),
         '.feather': FeatherFileProcessor(),
+        '.png': BinaryFileProcessor(),
+        '.jpg': BinaryFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ install_requires = [
     'redis',
 ]
 
+tests_require = [
+    'moto==1.3.6',
+    'testfixtures==6.14.2',
+    'matplotlib'
+]
+
 setup(
     name='gokart',
     use_scm_version=True,
@@ -32,7 +38,7 @@ setup(
     license='MIT License',
     packages=find_packages(),
     install_requires=install_requires,
-    tests_require=['moto==1.3.6', 'testfixtures==6.14.2'],
+    tests_require=tests_require,
     test_suite='test',
     classifiers=['Programming Language :: Python :: 3.6'],
 )


### PR DESCRIPTION
This resolves #148 

Add `gokart.file_processor.BinaryFileProcessor` which just pass `bytes` to target file.
TargetOnKart with files with '.png' or '.jpg' extentions will automatically use `BinaryFileProcessor`