### PR TITLE
set redis_timeout parameter as siginificant=False

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -51,7 +51,7 @@ class TaskOnKart(luigi.Task):
 
     redis_host = luigi.Parameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
     redis_port = luigi.Parameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
-    redis_timeout = luigi.IntParameter(default=180, description='Redis lock will be released after `redis_timeout` seconds')
+    redis_timeout = luigi.IntParameter(default=180, description='Redis lock will be released after `redis_timeout` seconds', significant=False)
 
     def __init__(self, *args, **kwargs):
         self._add_configuration(kwargs, 'TaskOnKart')

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -387,7 +387,7 @@ class TaskTest(unittest.TestCase):
 
         task = _Task(int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
         sub_task_id = _SubTask().make_unique_id()
-        expected = f'{__name__}._Task(redis_timeout=180, int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
+        expected = f'{__name__}._Task(int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
             f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'
         self.assertEqual(expected, str(task))
 


### PR DESCRIPTION
Bug fix for setting redis_timeout parameters as insignificant.

@Hi-king
Please review.