### PR TITLE
migrating slack_sdk from slackclient and cleanup

### DIFF
--- a/gokart/slack/slack_api.py
+++ b/gokart/slack/slack_api.py
@@ -1,8 +1,6 @@
 from logging import getLogger
-import time
 
-import slack
-from slack.errors import SlackApiError
+import slack_sdk
 
 logger = getLogger(__name__)
 
@@ -21,7 +19,7 @@ class FileNotUploadedError(RuntimeError):
 
 class SlackAPI(object):
     def __init__(self, token, channel: str, to_user: str) -> None:
-        self._client = slack.WebClient(token=token)
+        self._client = slack_sdk.WebClient(token=token)
         self._channel_id = self._get_channel_id(channel)
         self._to_user = to_user if to_user == '' or to_user.startswith('@') else '@' + to_user
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md'), encoding
 install_requires = [
     'luigi',
     'boto3',
-    'slackclient>=2.0.0',
+    'slack_sdk',
     'pandas',
     'numpy',
     'tqdm',

--- a/test/slack/test_slack_api.py
+++ b/test/slack/test_slack_api.py
@@ -4,8 +4,8 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from testfixtures import LogCapture
-from slack.web.slack_response import SlackResponse
-from slack import WebClient
+from slack_sdk.web.slack_response import SlackResponse
+from slack_sdk import WebClient
 
 import gokart.slack
 
@@ -23,7 +23,7 @@ def _slack_response(token, data):
 
 
 class TestSlackAPI(unittest.TestCase):
-    @mock.patch('gokart.slack.slack_api.slack.WebClient')
+    @mock.patch('gokart.slack.slack_api.slack_sdk.WebClient')
     def test_initialization_with_invalid_token(self, patch):
         def _conversations_list(params={}):
             return _slack_response(token='invalid', data={'ok': False, 'error': 'error_reason'})
@@ -37,7 +37,7 @@ class TestSlackAPI(unittest.TestCase):
             l.check(('gokart.slack.slack_api', 'WARNING',
                      'The job will start without slack notification: Channel test is not found in public channels.'))
 
-    @mock.patch('gokart.slack.slack_api.slack.WebClient')
+    @mock.patch('gokart.slack.slack_api.slack_sdk.WebClient')
     def test_invalid_channel(self, patch):
         def _conversations_list(params={}):
             return _slack_response(token='valid',
@@ -63,7 +63,7 @@ class TestSlackAPI(unittest.TestCase):
                 'The job will start without slack notification: Channel invalid_channel is not found in public channels.'
             ))
 
-    @mock.patch('gokart.slack.slack_api.slack.WebClient')
+    @mock.patch('gokart.slack.slack_api.slack_sdk.WebClient')
     def test_send_snippet_with_invalid_token(self, patch):
         def _conversations_list(params={}):
             return _slack_response(token='valid',
@@ -94,7 +94,7 @@ class TestSlackAPI(unittest.TestCase):
                 ('gokart.slack.slack_api', 'WARNING',
                  'Failed to send slack notification: Error while uploading file. The error reason is "error_reason".'))
 
-    @mock.patch('gokart.slack.slack_api.slack.WebClient')
+    @mock.patch('gokart.slack.slack_api.slack_sdk.WebClient')
     def test_send(self, patch):
         def _conversations_list(params={}):
             return _slack_response(token='valid',


### PR DESCRIPTION
Slack client version 3 is available and v2 will be deprecated soon.
In this PR, migrating to `slack_sdk` package.

ref: https://slack.dev/python-slack-sdk/v3-migration/
