### PR TITLE
Suppress redundant warning messages

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -51,8 +51,8 @@ class TaskOnKart(luigi.Task):
     fix_random_seed_methods = luigi.ListParameter(default=['random.seed', 'numpy.random.seed'], description='Fix random seed method list.', significant=False)
     fix_random_seed_value = luigi.IntParameter(default=None, description='Fix random seed method value.', significant=False)
 
-    redis_host = luigi.Parameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
-    redis_port = luigi.Parameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
+    redis_host = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
+    redis_port = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
     redis_timeout = luigi.IntParameter(default=180, description='Redis lock will be released after `redis_timeout` seconds', significant=False)
     redis_fail_on_collision: bool = luigi.BoolParameter(
         default=False,

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -178,13 +178,13 @@ class TaskTest(unittest.TestCase):
         task = _DummyTaskD()
         default_target = task.output()
         self.assertIsInstance(default_target, SingleFileTarget)
-        self.assertEqual(f'./resources/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.pkl', default_target._target.path)
+        self.assertEqual(f'./resources/test/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.pkl', default_target._target.path)
 
     def test_default_large_dataframe_target(self):
         task = _DummyTaskD()
         default_large_dataframe_target = task.make_large_data_frame_target()
         self.assertIsInstance(default_large_dataframe_target, ModelTarget)
-        self.assertEqual(f'./resources/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.zip', default_large_dataframe_target._zip_client._file_path)
+        self.assertEqual(f'./resources/test/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.zip', default_large_dataframe_target._zip_client._file_path)
 
     def test_make_target(self):
         task = _DummyTask()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -178,13 +178,13 @@ class TaskTest(unittest.TestCase):
         task = _DummyTaskD()
         default_target = task.output()
         self.assertIsInstance(default_target, SingleFileTarget)
-        self.assertEqual(f'./resources/test/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.pkl', default_target._target.path)
+        self.assertEqual(f'./resources/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.pkl', default_target._target.path)
 
     def test_default_large_dataframe_target(self):
         task = _DummyTaskD()
         default_large_dataframe_target = task.make_large_data_frame_target()
         self.assertIsInstance(default_large_dataframe_target, ModelTarget)
-        self.assertEqual(f'./resources/test/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.zip', default_large_dataframe_target._zip_client._file_path)
+        self.assertEqual(f'./resources/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.zip', default_large_dataframe_target._zip_client._file_path)
 
     def test_make_target(self):
         task = _DummyTask()


### PR DESCRIPTION
Fixed `luigi.Parameter` --> `luigi.OptionalParameter` to suppress redundant warning messages
https://github.com/m3dev/gokart/issues/166

thx! @skokado

Please review!
@hirosassa @Hi-king @vaaaaanquish 