### PR TITLE
make s3 config singleton

### DIFF
--- a/gokart/s3_config.py
+++ b/gokart/s3_config.py
@@ -8,6 +8,13 @@ class S3Config(luigi.Config):
     aws_access_key_id_name = luigi.Parameter(default='AWS_ACCESS_KEY_ID', description='AWS access key id environment variable.')
     aws_secret_access_key_name = luigi.Parameter(default='AWS_SECRET_ACCESS_KEY', description='AWS secret access key environment variable.')
 
+    _client = None
+
     def get_s3_client(self) -> luigi.contrib.s3.S3Client:
+        if self._client is None:  # use cache as like singleton object
+            self._client = self._get_s3_client()
+        return self._client
+
+    def _get_s3_client(self) -> luigi.contrib.s3.S3Client:
         return luigi.contrib.s3.S3Client(aws_access_key_id=os.environ.get(self.aws_access_key_id_name),
                                          aws_secret_access_key=os.environ.get(self.aws_secret_access_key_name))

--- a/test/test_s3_config.py
+++ b/test/test_s3_config.py
@@ -1,0 +1,13 @@
+import os
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+from gokart.s3_config import S3Config
+
+
+class TestS3Config(unittest.TestCase):
+    def test_get_same_s3_client(self):
+        client_a = S3Config().get_s3_client()
+        client_b = S3Config().get_s3_client()
+
+        self.assertEqual(client_a, client_b)


### PR DESCRIPTION
[What?]
I've made S3Config's S3Client as singleton.

[Why?]
The original code makes one S3Client for each loading file, which causes connection error when loading many files from S3.


Please review!
@Hi-king @hirosassa @vaaaaanquish 