### PR TITLE
compress info tree

### DIFF
--- a/docs/task_information.rst
+++ b/docs/task_information.rst
@@ -8,6 +8,10 @@ There are two ways to print the significant parameters and state of the task and
 One is to use luigi module. See `luigi.tools.deps_tree module <https://luigi.readthedocs.io/en/stable/api/luigi.tools.deps_tree.html>`_ for details.
 Another is to use ``task-info`` option which is implemented in gokart.
 
+
+On CLI
+~~~~~~
+
 An example implementation could be like:
 
 .. code:: python
@@ -49,6 +53,85 @@ An example output is as follows:
 
     └─-(COMPLETE) TaskB[09fe5591ef2969ce7443c419a3b19e5d](parameter={'workspace_directory': './resources/', 'local_temporary_directory': './resources/tmp/', 'param': 'Hello'}, output=['./resources/output_of_task_b_09fe5591ef2969ce7443c419a3b19e5d.pkl'], time=0.002290010452270508s, task_log={})
        └─-(COMPLETE) TaskA[2549878535c070fb6c3cd4061bdbbcff](parameter={'workspace_directory': './resources/', 'local_temporary_directory': './resources/tmp/', 'param': 'called by TaskB'}, output=['./resources/output_of_task_a_2549878535c070fb6c3cd4061bdbbcff.pkl'], time=0.0009829998016357422s, task_log={})
+
+
+On Python
+~~~~~~~~~
+
+It use :func:`~gokart.info.make_tree_info` in the following:
+
+
+.. code:: python
+
+    import luigi
+    import gokart
+
+    class TaskA(gokart.TaskOnKart):
+        param = luigi.Parameter()
+        def run(self):
+            self.dump(f'{self.param}')
+
+    class TaskB(gokart.TaskOnKart):
+        task = gokart.TaskInstanceParameter()
+        def run(self):
+            task = self.load('task')
+            self.dump(task + ' taskB')
+
+    class TaskC(gokart.TaskOnKart):
+        task = gokart.TaskInstanceParameter()
+        def run(self):
+            task = self.load('task')
+            self.dump(task + ' taskC')
+
+    class TaskD(gokart.TaskOnKart):
+        task1 = gokart.TaskInstanceParameter()
+        task2 = gokart.TaskInstanceParameter()
+        def run(self):
+            task = [self.load('task1'), self.load('task2')]
+            self.dump(','.join(task))
+
+
+The more dependencies you have, the harder it is to see the tree.
+
+
+.. code:: python
+
+    task = TaskD(
+        task1=TaskD(
+            task1=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar')))),  # same task
+            task2=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar'))))   # same task
+        ),
+        task2=TaskD(
+            task1=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar')))),  # same task
+            task2=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar'))))   # same task
+        )
+    )
+    print(gokart.make_tree_info(task))
+
+
+.. code:: sh
+
+    └─-(PENDING) TaskD[187ff82158671283e127e2e1f7c9c095]
+        |--(PENDING) TaskD[ca9e943ce049e992b371898c0578784e]    # duplicated TaskD
+        |  |--(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]    # duplicated TaskD
+        |  |  |--(PENDING) TaskC[dce3d8e7acaf1bb9731fb4f2ae94e473]
+        |  |  |  └─-(PENDING) TaskA[be65508b556dd3752359b4246791413d]
+        |  |  └─-(PENDING) TaskC[de39593d31490aba3cdca3c650432504]
+        |  |     └─-(PENDING) TaskB[bc2f7d6cdd6521cc116c35f0f144eed3]
+        |  |        └─-(PENDING) TaskA[5a824f7d232eb69d46f0ac6bbd93b565]
+        |  └─-(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
+        |     └─- ...
+        └─-(PENDING) TaskD[ca9e943ce049e992b371898c0578784e]
+            └─- ...
+
+
+This has been omitted.
+We can disable compress by doing the following:
+
+.. code:: python
+
+    print(make_tree_info(task, compress=False))
+
 
 
 Task Logs

--- a/docs/task_information.rst
+++ b/docs/task_information.rst
@@ -126,11 +126,11 @@ The more dependencies you have, the harder it is to see the tree.
 
 
 In task dependency tree output by `make_tree_info`, the sub-trees already shown in above will be omitted.
-We can disable compress by doing the following:
+We can disable abbreviation by doing the following:
 
 .. code:: python
 
-    print(make_tree_info(task, compress=False))
+    print(make_tree_info(task, abbr=False))
 
 
 

--- a/docs/task_information.rst
+++ b/docs/task_information.rst
@@ -125,7 +125,7 @@ The more dependencies you have, the harder it is to see the tree.
             └─- ...
 
 
-This has been omitted.
+In task dependency tree output by `make_tree_info`, the sub-trees already shown in above will be omitted.
 We can disable compress by doing the following:
 
 .. code:: python

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -8,7 +8,7 @@ from gokart.task import TaskOnKart
 logger = getLogger(__name__)
 
 
-def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_list=None):
+def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_set=None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
     """
@@ -27,10 +27,10 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_li
     result += f'({is_complete}) {name}[{task.make_unique_id()}]'
 
     if abbr:
-        task_list = [] if not task_list else task_list
+        task_set = task_set or {}
         task_id = f'{name}_{task.make_unique_id()}'
-        if task_id not in task_list:
-            task_list.append(task_id)
+        if task_id not in task_set:
+            task_set.add(task_id)
         else:
             result += f'\n{indent}└─- ...'
             return result
@@ -45,7 +45,7 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_li
 
     children = luigi.task.flatten(task.requires())
     for index, child in enumerate(children):
-        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, task_list=task_list)
+        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, task_set=task_set)
     return result
 
 

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -8,7 +8,7 @@ from gokart.task import TaskOnKart
 logger = getLogger(__name__)
 
 
-def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_set=None):
+def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited_tasks=None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
     """
@@ -27,10 +27,10 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_se
     result += f'({is_complete}) {name}[{task.make_unique_id()}]'
 
     if abbr:
-        task_set = task_set or {}
+        visited_tasks = visited_tasks or {}
         task_id = f'{name}_{task.make_unique_id()}'
-        if task_id not in task_set:
-            task_set.add(task_id)
+        if task_id not in visited_tasks:
+            visited_tasks.add(task_id)
         else:
             result += f'\n{indent}└─- ...'
             return result
@@ -45,7 +45,7 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_se
 
     children = luigi.task.flatten(task.requires())
     for index, child in enumerate(children):
-        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, task_set=task_set)
+        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, visited_tasks=visited_tasks)
     return result
 
 

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -8,7 +8,7 @@ from gokart.task import TaskOnKart
 logger = getLogger(__name__)
 
 
-def make_tree_info(task, indent='', last=True, details=False, compress=True, task_list=None):
+def make_tree_info(task, indent='', last=True, details=False, abbr=True, task_list=None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
     """
@@ -26,7 +26,7 @@ def make_tree_info(task, indent='', last=True, details=False, compress=True, tas
     name = task.__class__.__name__
     result += f'({is_complete}) {name}[{task.make_unique_id()}]'
 
-    if compress:
+    if abbr:
         task_list = [] if not task_list else task_list
         task_id = f'{name}_{task.make_unique_id()}'
         if task_id not in task_list:
@@ -45,7 +45,7 @@ def make_tree_info(task, indent='', last=True, details=False, compress=True, tas
 
     children = luigi.task.flatten(task.requires())
     for index, child in enumerate(children):
-        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, compress=compress, task_list=task_list)
+        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, task_list=task_list)
     return result
 
 

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -8,7 +8,7 @@ from gokart.task import TaskOnKart
 logger = getLogger(__name__)
 
 
-def make_tree_info(task, indent='', last=True, details=False, abbreviation=True, task_list=None):
+def make_tree_info(task, indent='', last=True, details=False, compress=True, task_list=None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
     """
@@ -26,7 +26,7 @@ def make_tree_info(task, indent='', last=True, details=False, abbreviation=True,
     name = task.__class__.__name__
     result += f'({is_complete}) {name}[{task.make_unique_id()}]'
 
-    if abbreviation:
+    if compress:
         task_list = [] if not task_list else task_list
         task_id = f'{name}_{task.make_unique_id()}'
         if task_id not in task_list:
@@ -45,7 +45,7 @@ def make_tree_info(task, indent='', last=True, details=False, abbreviation=True,
 
     children = luigi.task.flatten(task.requires())
     for index, child in enumerate(children):
-        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbreviation=abbreviation, task_list=task_list)
+        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, compress=compress, task_list=task_list)
     return result
 
 


### PR DESCRIPTION
fix: #89

For example:
```python
import luigi
import gokart

class TaskA(gokart.TaskOnKart):
    param = luigi.Parameter()
    def run(self):
        self.dump(f'{self.param}')

class TaskB(gokart.TaskOnKart):
    task = gokart.TaskInstanceParameter()
    def run(self):
        task = self.load('task')
        self.dump(task + ' taskB')
        
class TaskC(gokart.TaskOnKart):
    task = gokart.TaskInstanceParameter()
    def run(self):
        task = self.load('task')
        self.dump(task + ' taskC')
        
class TaskD(gokart.TaskOnKart):
    task1 = gokart.TaskInstanceParameter()
    task2 = gokart.TaskInstanceParameter()
    def run(self):
        task = [self.load('task1'), self.load('task2')]
        self.dump(','.join(task))
```

The more dependencies you have, the harder it is to see the tree.
```python
task = TaskD(
    task1=TaskD(
        task1=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar')))),  # same task
        task2=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar'))))   # same task
    ),
    task2=TaskD(
        task1=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar')))),  # same task
        task2=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar'))))   # same task
    )
)
print(gokart.make_tree_info(task))
```

```
└─-(PENDING) TaskD[187ff82158671283e127e2e1f7c9c095]
   |--(PENDING) TaskD[ca9e943ce049e992b371898c0578784e]
   |  |--(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
   |  |  |--(PENDING) TaskC[dce3d8e7acaf1bb9731fb4f2ae94e473]
   |  |  |  └─-(PENDING) TaskA[be65508b556dd3752359b4246791413d]
   |  |  └─-(PENDING) TaskC[de39593d31490aba3cdca3c650432504]
   |  |     └─-(PENDING) TaskB[bc2f7d6cdd6521cc116c35f0f144eed3]
   |  |        └─-(PENDING) TaskA[5a824f7d232eb69d46f0ac6bbd93b565]
   |  └─-(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
   |     |--(PENDING) TaskC[dce3d8e7acaf1bb9731fb4f2ae94e473]
   |     |  └─-(PENDING) TaskA[be65508b556dd3752359b4246791413d]
   |     └─-(PENDING) TaskC[de39593d31490aba3cdca3c650432504]
   |        └─-(PENDING) TaskB[bc2f7d6cdd6521cc116c35f0f144eed3]
   |           └─-(PENDING) TaskA[5a824f7d232eb69d46f0ac6bbd93b565]
   └─-(PENDING) TaskD[ca9e943ce049e992b371898c0578784e]
      |--(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
      |  |--(PENDING) TaskC[dce3d8e7acaf1bb9731fb4f2ae94e473]
      |  |  └─-(PENDING) TaskA[be65508b556dd3752359b4246791413d]
      |  └─-(PENDING) TaskC[de39593d31490aba3cdca3c650432504]
      |     └─-(PENDING) TaskB[bc2f7d6cdd6521cc116c35f0f144eed3]
      |        └─-(PENDING) TaskA[5a824f7d232eb69d46f0ac6bbd93b565]
      └─-(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
         |--(PENDING) TaskC[dce3d8e7acaf1bb9731fb4f2ae94e473]
         |  └─-(PENDING) TaskA[be65508b556dd3752359b4246791413d]
         └─-(PENDING) TaskC[de39593d31490aba3cdca3c650432504]
            └─-(PENDING) TaskB[bc2f7d6cdd6521cc116c35f0f144eed3]
               └─-(PENDING) TaskA[5a824f7d232eb69d46f0ac6bbd93b565]
```

This change will result in the following:
```
└─-(PENDING) TaskD[187ff82158671283e127e2e1f7c9c095]
   |--(PENDING) TaskD[ca9e943ce049e992b371898c0578784e]
   |  |--(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
   |  |  |--(PENDING) TaskC[dce3d8e7acaf1bb9731fb4f2ae94e473]
   |  |  |  └─-(PENDING) TaskA[be65508b556dd3752359b4246791413d]
   |  |  └─-(PENDING) TaskC[de39593d31490aba3cdca3c650432504]
   |  |     └─-(PENDING) TaskB[bc2f7d6cdd6521cc116c35f0f144eed3]
   |  |        └─-(PENDING) TaskA[5a824f7d232eb69d46f0ac6bbd93b565]
   |  └─-(PENDING) TaskD[1cc9f9fc54a56614f3adef74398684f4]
   |     └─- ...
   └─-(PENDING) TaskD[ca9e943ce049e992b371898c0578784e]
      └─- ...
```

We can disable it by doing the following:
```python
print(make_tree_info(task, compress=False))
```