### PR TITLE
Add parameter alias to inherits_config_params

### DIFF
--- a/docs/setting_task_parameters.rst
+++ b/docs/setting_task_parameters.rst
@@ -53,3 +53,19 @@ This is useful when multiple tasks has the same parameter, since parameter setti
 
 Note that parameters which exist in both ``MasterConfig`` and ``SomeTask`` will be inherited.
 In the above example, ``param2`` will not be available in ``SomeTask``, since ``SomeTask`` does not have ``param2`` parameter.
+
+.. code:: python
+
+    class MasterConfig(luigi.Config):
+        param: str = luigi.Parameter()
+        param2: str = luigi.Parameter()
+
+    @inherits_config_params(MasterConfig, param_config2task={'param2': 'param3'})
+    class SomeTask(gokart.TaskOnKart):
+        param3: str = luigi.Parameter()
+
+
+You may also set a parameter name alias by setting ``param_config2task``.
+``param_config2task`` must be a dictionary of inheriting task's parameter name as keys and decorating task's parameter names as values.
+
+In the above example, ``SomeTask.param3`` will be set to same value as ``MasterConfig.param2``.

--- a/docs/setting_task_parameters.rst
+++ b/docs/setting_task_parameters.rst
@@ -60,12 +60,12 @@ In the above example, ``param2`` will not be available in ``SomeTask``, since ``
         param: str = luigi.Parameter()
         param2: str = luigi.Parameter()
 
-    @inherits_config_params(MasterConfig, param_config2task={'param2': 'param3'})
+    @inherits_config_params(MasterConfig, parameter_alias={'param2': 'param3'})
     class SomeTask(gokart.TaskOnKart):
         param3: str = luigi.Parameter()
 
 
-You may also set a parameter name alias by setting ``param_config2task``.
-``param_config2task`` must be a dictionary of inheriting task's parameter name as keys and decorating task's parameter names as values.
+You may also set a parameter name alias by setting ``parameter_alias``.
+``parameter_alias`` must be a dictionary of inheriting task's parameter name as keys and decorating task's parameter names as values.
 
 In the above example, ``SomeTask.param3`` will be set to same value as ``MasterConfig.param2``.

--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -6,17 +6,17 @@ import gokart
 
 
 class inherits_config_params:
-    def __init__(self, config_class: luigi.Config, param_config2task: Optional[Dict[str, str]] = None):
+    def __init__(self, config_class: luigi.Config, parameter_alias: Optional[Dict[str, str]] = None):
         """
         Decorates task to inherit parameter value of `config_class`.
 
         * config_class: Inherit parameter value of this task to decorated task. Only parameter values exist in both tasks are inherited.
-        * param_config2task: Dictionary to map paramter names between config_class and decorated task.
-                             key: config_class's parameter name. value: decorated task's parameter name.
+        * parameter_alias: Dictionary to map paramter names between config_class task and decorated task.
+                           key: config_class's parameter name. value: decorated task's parameter name.
         """
 
         self._config_class: luigi.Config = config_class
-        self._param_config2task: Dict[str, str] = param_config2task if param_config2task is not None else {}
+        self._parameter_alias: Dict[str, str] = parameter_alias if parameter_alias is not None else {}
 
     def __call__(self, task: gokart.TaskOnKart):
         # wrap task to prevent task name from being changed
@@ -25,7 +25,7 @@ class inherits_config_params:
             @classmethod
             def get_param_values(cls, params, args, kwargs):
                 for param_key, param_value in self._config_class().param_kwargs.items():
-                    task_param_key = self._param_config2task.get(param_key, param_key)
+                    task_param_key = self._parameter_alias.get(param_key, param_key)
 
                     if hasattr(cls, task_param_key) and task_param_key not in kwargs:
                         kwargs[task_param_key] = param_value

--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -1,23 +1,25 @@
+from typing import Dict, Optional
 import luigi
 
 import gokart
 
 
 class inherits_config_params:
-    def __init__(self, config_class: luigi.Config):
-        self.config_class: luigi.Config = config_class
+    def __init__(self, config_class: luigi.Config, param_config2task: Optional[Dict[str, str]] = None):
+        self._config_class: luigi.Config = config_class
+        self._param_config2task: Dict[str, str] = param_config2task if param_config2task is not None else {}
 
     def __call__(self, task: gokart.TaskOnKart):
-        config_class = self.config_class
-
         # wrap task to prevent task name from being changed
         @luigi.task._task_wraps(task)
         class Wrapped(task):
             @classmethod
             def get_param_values(cls, params, args, kwargs):
-                for k, v in config_class().param_kwargs.items():
-                    if hasattr(cls, k) and k not in kwargs:
-                        kwargs[k] = v
+                for param_key, param_value in self._config_class().param_kwargs.items():
+                    task_param_key = self._param_config2task.get(param_key, param_key)
+
+                    if hasattr(cls, task_param_key) and task_param_key not in kwargs:
+                        kwargs[task_param_key] = param_value
                 return super(Wrapped, cls).get_param_values(params, args, kwargs)
 
         return Wrapped

--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional
+
 import luigi
 
 import gokart

--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -8,7 +8,7 @@ import gokart
 class inherits_config_params:
     def __init__(self, config_class: luigi.Config, param_config2task: Optional[Dict[str, str]] = None):
         """
-        Decorates task to inherit parameter of `config_class`.
+        Decorates task to inherit parameter value of `config_class`.
 
         * config_class: Inherit parameter value of this task to decorated task. Only parameter values exist in both tasks are inherited.
         * param_config2task: Dictionary to map paramter names between config_class and decorated task.

--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -10,8 +10,8 @@ class inherits_config_params:
         """
         Decorates task to inherit parameter of `config_class`.
 
-        * config_class: Inherit parameter value of this task to decorated task. Only parameters exist in both tasks are inherited.
-        * param_config2task: Dictinary to map paramter names between config_class and decorated task.
+        * config_class: Inherit parameter value of this task to decorated task. Only parameter values exist in both tasks are inherited.
+        * param_config2task: Dictionary to map paramter names between config_class and decorated task.
                              key: config_class's parameter name. value: decorated task's parameter name.
         """
 

--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -7,6 +7,14 @@ import gokart
 
 class inherits_config_params:
     def __init__(self, config_class: luigi.Config, param_config2task: Optional[Dict[str, str]] = None):
+        """
+        Decorates task to inherit parameter of `config_class`.
+
+        * config_class: Inherit parameter value of this task to decorated task. Only parameters exist in both tasks are inherited.
+        * param_config2task: Dictinary to map paramter names between config_class and decorated task.
+                             key: config_class's parameter name. value: decorated task's parameter name.
+        """
+
         self._config_class: luigi.Config = config_class
         self._param_config2task: Dict[str, str] = param_config2task if param_config2task is not None else {}
 

--- a/test/test_config_params.py
+++ b/test/test_config_params.py
@@ -25,6 +25,12 @@ class Inherited(gokart.TaskOnKart):
     param_b = luigi.Parameter(default='overrided')
 
 
+@inherits_config_params(ConfigClass, param_config2task={'param_a': 'param_d'})
+class Inherited2(gokart.TaskOnKart):
+    param_c = luigi.Parameter()
+    param_d = luigi.Parameter()
+
+
 class ChildTask(Inherited):
     pass
 
@@ -56,6 +62,10 @@ class TestInheritsConfigParam(unittest.TestCase):
         # Parameters which is not a member of the task will not be set
         with self.assertRaises(AttributeError):
             in_parse(['Inherited'], lambda task: task.param_c)
+
+        # test parameter name alias
+        in_parse(['Inherited2'], lambda task: self.assertEqual(task.param_c, 'config c'))
+        in_parse(['Inherited2'], lambda task: self.assertEqual(task.param_d, 'config a'))
 
     def test_child_task(self):
         in_parse(['ChildTask'], lambda task: self.assertEqual(task.param_a, 'config a'))

--- a/test/test_config_params.py
+++ b/test/test_config_params.py
@@ -25,7 +25,7 @@ class Inherited(gokart.TaskOnKart):
     param_b = luigi.Parameter(default='overrided')
 
 
-@inherits_config_params(ConfigClass, param_config2task={'param_a': 'param_d'})
+@inherits_config_params(ConfigClass, parameter_alias={'param_a': 'param_d'})
 class Inherited2(gokart.TaskOnKart):
     param_c = luigi.Parameter()
     param_d = luigi.Parameter()


### PR DESCRIPTION
This update allows to replace parameter name of inherited config Task, when using `@inherits_config_params` decorator.

Currently, when using `@inherits_config_params`, parameter name of inheriting config Task and decorated Task must be same. After this PR, parameter name can be replaced by passing parameter names dictionary `param_config2task` to `@inherits_config_params` decorator.

Please review!
@hirosassa @vaaaaanquish @e-mon @Hi-king 