### PR TITLE
🐛 Hotfix: Should use set() for empty set declaration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   tests:

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -27,7 +27,7 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited
     result += f'({is_complete}) {name}[{task.make_unique_id()}]'
 
     if abbr:
-        visited_tasks = visited_tasks or {}
+        visited_tasks = visited_tasks or set()
         task_id = f'{name}_{task.make_unique_id()}'
         if task_id not in visited_tasks:
             visited_tasks.add(task_id)

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -75,7 +75,7 @@ class TestInfo(unittest.TestCase):
         self.assertRegex(tree, expected)
 
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
-    def test_make_tree_info_compress(self):
+    def test_make_tree_info_abbreviation(self):
         task = _DoubleLoadSubTask(
             sub1=_Task(param=1, sub=_SubTask(param=2)),
             sub2=_Task(param=1, sub=_SubTask(param=2)),
@@ -101,7 +101,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = gokart.info.make_tree_info(task, compress=False)
+        tree = gokart.info.make_tree_info(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
    |--\(COMPLETE\) _Task\[[a-z0-9]*\]


### PR DESCRIPTION
- An one-line fix, `set()`
- small fixes on test
- CI runs on any PRs