### PR TITLE
fix logo image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gokart
 
 <p align="center">
-  <img src="./docs/gokart_logo_side_isolation.svg" width="90%">
+  <img src="https://raw.githubusercontent.com/m3dev/gokart/master/docs/gokart_logo_side_isolation.svg" width="90%">
 <p>
 
 [![Test](https://github.com/m3dev/gokart/workflows/Test/badge.svg)](https://github.com/m3dev/gokart/actions?query=workflow%3ATest)


### PR DESCRIPTION
I've fixed the logo image url to make it visible at pypi page.

Currently, the logo is not shown at pypi.
![image](https://user-images.githubusercontent.com/34547057/116261987-2106a400-a7b3-11eb-8d79-b7084af91a6d.png)

To appear logo at pypi page, we have to convert image url link to an external link.
https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github/46875147

Please review!
@vaaaaanquish @hirosassa @Hi-king 