### PR TITLE
Fix add_config behavior

### DIFF
--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -24,3 +24,4 @@ def add_config(file_path: str):
     _, ext = os.path.splitext(file_path)
     luigi.configuration.core.parser = ext
     assert luigi.configuration.add_config_path(file_path)
+    read_environ()

--- a/test/config/test_config.ini
+++ b/test/config/test_config.ini
@@ -1,2 +1,5 @@
 [_DummyTask]
 param = %(test_param)s
+
+[test_build._DummyTask]
+param = %(test_param)s

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from copy import copy
 
 import luigi
 import luigi.mock
@@ -21,7 +22,12 @@ class _DummyTask(gokart.TaskOnKart):
 class RunTest(unittest.TestCase):
     def setUp(self):
         luigi.configuration.LuigiConfigParser._instance = None
+        self.config_paths = copy(luigi.configuration.LuigiConfigParser._config_paths)
         luigi.mock.MockFileSystem().clear()
+        os.environ.clear()
+    
+    def tearDown(self) -> None:
+        luigi.configuration.LuigiConfigParser._config_paths = self.config_paths
         os.environ.clear()
 
     def test_build(self):
@@ -31,9 +37,9 @@ class RunTest(unittest.TestCase):
 
     def test_read_config(self):
         os.environ.setdefault('test_param', 'test')
-        config_file_path = os.path.join(os.path.dirname(__name__), 'config', 'test_config.ini')
+        config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config', 'test_config.ini')
         gokart.utils.add_config(config_file_path)
-        output = gokart.build(_DummyTask())
+        output = gokart.build(_DummyTask(), reset_register=False)
         self.assertEqual(output, 'test')
 
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -25,8 +25,8 @@ class RunTest(unittest.TestCase):
         self.config_paths = copy(luigi.configuration.LuigiConfigParser._config_paths)
         luigi.mock.MockFileSystem().clear()
         os.environ.clear()
-    
-    def tearDown(self) -> None:
+
+    def tearDown(self):
         luigi.configuration.LuigiConfigParser._config_paths = self.config_paths
         os.environ.clear()
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -29,6 +29,13 @@ class RunTest(unittest.TestCase):
         output = gokart.build(_DummyTask(param=text), reset_register=False)
         self.assertEqual(output, text)
 
+    def test_read_config(self):
+        os.environ.setdefault('test_param', 'test')
+        config_file_path = os.path.join(os.path.dirname(__name__), 'config', 'test_config.ini')
+        gokart.utils.add_config(config_file_path)
+        output = gokart.build(_DummyTask())
+        self.assertEqual(output, 'test')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following error occurs when adding a configuration file with environment variables.

base.ini
```ini
[Example]
param = %(param)s
```

example.py
```pyuthon
import gokart

class Example(gokart.TaskOnKart):
    param = luigi.Parameter()

    def run(self):
        self.dump('Hello, world!')

gokart.add_config('base.ini')
task = Example()
output = gokart.build(task)
```

erorr
```
configparser.InterpolationMissingOptionError: Bad value substitution: option 'param' in section 'Example' contains an interpolation key 'test_param' which is not a valid option name. Raw value: '%(test_param)s'
```

I think this is because the environment variables are not loaded before the parameter parsing, so I fixed `config_add` function.

Please review.