### PR TITLE
[bugfix] Should clone rerun if explicitly passed as self.clone(cls, rerun=True)

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -131,17 +131,15 @@ class TaskOnKart(luigi.Task):
         return input_modification_time <= output_modification_time
 
     def clone(self, cls=None, **kwargs):
+        _SPECIAL_PARAMS = {'rerun', 'strict_check', 'modification_time_check'}
         if cls is None:
             cls = self.__class__
 
         new_k = {}
         for param_name, param_class in cls.get_params():
-            if param_name in {'rerun', 'strict_check', 'modification_time_check'}:
-                continue
-
             if param_name in kwargs:
                 new_k[param_name] = kwargs[param_name]
-            elif hasattr(self, param_name):
+            elif hasattr(self, param_name) and (param_name not in _SPECIAL_PARAMS):
                 new_k[param_name] = getattr(self, param_name)
 
         return cls(**new_k)

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -12,7 +12,7 @@ from gokart.file_processor import XmlFileProcessor
 from gokart.parameter import ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.run_with_lock import RunWithLock
 from gokart.target import ModelTarget, SingleFileTarget, TargetOnKart
-
+import pathlib
 
 class _DummyTask(gokart.TaskOnKart):
     task_namespace = __name__
@@ -178,13 +178,19 @@ class TaskTest(unittest.TestCase):
         task = _DummyTaskD()
         default_target = task.output()
         self.assertIsInstance(default_target, SingleFileTarget)
-        self.assertEqual(f'./resources/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.pkl', default_target._target.path)
+        self.assertEqual(
+            f'_DummyTaskD_{task.task_unique_id}.pkl',
+            pathlib.Path(default_target._target.path).name
+        )
 
     def test_default_large_dataframe_target(self):
         task = _DummyTaskD()
         default_large_dataframe_target = task.make_large_data_frame_target()
         self.assertIsInstance(default_large_dataframe_target, ModelTarget)
-        self.assertEqual(f'./resources/test_task_on_kart/_DummyTaskD_{task.task_unique_id}.zip', default_large_dataframe_target._zip_client._file_path)
+        self.assertEqual(
+            f'_DummyTaskD_{task.task_unique_id}.zip',
+            pathlib.Path(default_large_dataframe_target._zip_client._file_path).name
+        )
 
     def test_make_target(self):
         task = _DummyTask()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -183,6 +183,17 @@ class TaskTest(unittest.TestCase):
             pathlib.Path(default_target._target.path).name
         )
 
+    def test_clone_with_special_params(self):
+        class _DummyTaskRerun(gokart.TaskOnKart):
+            a=luigi.BoolParameter(default=False)
+        task = _DummyTaskRerun(a=True, rerun=True)
+        cloned = task.clone(_DummyTaskRerun)
+        cloned_with_explicit_rerun = task.clone(_DummyTaskRerun, rerun=True)
+        self.assertTrue(cloned.a)
+        self.assertFalse(cloned.rerun)  # do not clone rerun
+        self.assertTrue(cloned_with_explicit_rerun.a)
+        self.assertTrue(cloned_with_explicit_rerun.rerun)
+
     def test_default_large_dataframe_target(self):
         task = _DummyTaskD()
         default_large_dataframe_target = task.make_large_data_frame_target()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -12,7 +13,6 @@ from gokart.file_processor import XmlFileProcessor
 from gokart.parameter import ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.run_with_lock import RunWithLock
 from gokart.target import ModelTarget, SingleFileTarget, TargetOnKart
-import pathlib
 
 
 class _DummyTask(gokart.TaskOnKart):

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -14,6 +14,7 @@ from gokart.run_with_lock import RunWithLock
 from gokart.target import ModelTarget, SingleFileTarget, TargetOnKart
 import pathlib
 
+
 class _DummyTask(gokart.TaskOnKart):
     task_namespace = __name__
     param = luigi.IntParameter(default=1)
@@ -178,14 +179,12 @@ class TaskTest(unittest.TestCase):
         task = _DummyTaskD()
         default_target = task.output()
         self.assertIsInstance(default_target, SingleFileTarget)
-        self.assertEqual(
-            f'_DummyTaskD_{task.task_unique_id}.pkl',
-            pathlib.Path(default_target._target.path).name
-        )
+        self.assertEqual(f'_DummyTaskD_{task.task_unique_id}.pkl', pathlib.Path(default_target._target.path).name)
 
     def test_clone_with_special_params(self):
         class _DummyTaskRerun(gokart.TaskOnKart):
             a = luigi.BoolParameter(default=False)
+
         task = _DummyTaskRerun(a=True, rerun=True)
         cloned = task.clone(_DummyTaskRerun)
         cloned_with_explicit_rerun = task.clone(_DummyTaskRerun, rerun=True)
@@ -198,10 +197,7 @@ class TaskTest(unittest.TestCase):
         task = _DummyTaskD()
         default_large_dataframe_target = task.make_large_data_frame_target()
         self.assertIsInstance(default_large_dataframe_target, ModelTarget)
-        self.assertEqual(
-            f'_DummyTaskD_{task.task_unique_id}.zip',
-            pathlib.Path(default_large_dataframe_target._zip_client._file_path).name
-        )
+        self.assertEqual(f'_DummyTaskD_{task.task_unique_id}.zip', pathlib.Path(default_large_dataframe_target._zip_client._file_path).name)
 
     def test_make_target(self):
         task = _DummyTask()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -185,7 +185,7 @@ class TaskTest(unittest.TestCase):
 
     def test_clone_with_special_params(self):
         class _DummyTaskRerun(gokart.TaskOnKart):
-            a=luigi.BoolParameter(default=False)
+            a = luigi.BoolParameter(default=False)
         task = _DummyTaskRerun(a=True, rerun=True)
         cloned = task.clone(_DummyTaskRerun)
         cloned_with_explicit_rerun = task.clone(_DummyTaskRerun, rerun=True)


### PR DESCRIPTION
closes: #219 

As rerun is special parameter, it should not be implicitly cloned.
But sometimes we should pass rerun=true with clone() !

```
task = _DummyTaskRerun(a=True, rerun=True)
cloned = task.clone(_DummyTaskRerun)
cloned_with_explicit_rerun = task.clone(_DummyTaskRerun, rerun=True)

self.assertTrue(cloned.a)
self.assertFalse(cloned.rerun)  # do not clone rerun

self.assertTrue(cloned_with_explicit_rerun.a)
self.assertTrue(cloned_with_explicit_rerun.rerun)
```

