### PR TITLE
fix LoggerConfig inconsistency bug

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -16,12 +16,12 @@ class LoggerConfig:
         self.level = level
 
     def __enter__(self):
-        logging.disable(self.level)
+        logging.disable(self.level - 10)
         self.logger.setLevel(self.level)
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        logging.disable(self.default_level)
+        logging.disable(self.default_level - 10)
         self.logger.setLevel(self.default_level)
 
 

--- a/gokart/build.py
+++ b/gokart/build.py
@@ -16,12 +16,12 @@ class LoggerConfig:
         self.level = level
 
     def __enter__(self):
-        logging.disable(self.level - 10)
+        logging.disable(self.level - 10)  # subtract 10 to disable below self.level
         self.logger.setLevel(self.level)
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        logging.disable(self.default_level - 10)
+        logging.disable(self.default_level - 10)  # subtract 10 to disable below self.level
         self.logger.setLevel(self.default_level)
 
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -68,10 +68,15 @@ class RunTest(unittest.TestCase):
 
 class LoggerConfigTest(unittest.TestCase):
     def test_logger_config(self):
-        for level, expected in ((logging.INFO, logging.INFO), (logging.DEBUG, logging.DEBUG), (logging.CRITICAL, logging.CRITICAL)):
-            with self.subTest(level=level, expected=expected):
+        for level, enable_expected, disable_expected in (
+            (logging.INFO, logging.INFO, logging.DEBUG),
+            (logging.DEBUG, logging.DEBUG, logging.NOTSET),
+            (logging.CRITICAL, logging.CRITICAL, logging.ERROR),
+        ):
+            with self.subTest(level=level, enable_expected=enable_expected, disable_expected=disable_expected):
                 with LoggerConfig(level) as lc:
-                    self.assertEqual(lc.logger.level, expected)
+                    self.assertTrue(lc.logger.isEnabledFor(enable_expected))
+                    self.assertTrue(not lc.logger.isEnabledFor(disable_expected))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`gokart.build()` has a feature to disable low important logs.
However, the implementation has inconsistency, 
- logging.disable(self.level): disable any logs with level same or below the self.level
- self.logger.setLevel(self.level): enable any logs same or above the self.level

This is because logging.Logger.setLevel and logging.disable has the following difference.

> setLevel: Logging messages which **_are less severe than_** level will be ignored
> logging.disable: disable all logging calls of **_severity level and below_**


This PR fix the inconsistency by `disabling any logs with level below the self.level`