### PR TITLE
Refactored make_tree_info

### DIFF
--- a/docs/task_information.rst
+++ b/docs/task_information.rst
@@ -58,7 +58,7 @@ An example output is as follows:
 On Python
 ~~~~~~~~~
 
-It use :func:`~gokart.info.make_tree_info` in the following:
+It use :func:`~gokart.tree.task_info.make_tree_info_string` in the following:
 
 
 .. code:: python
@@ -106,7 +106,7 @@ The more dependencies you have, the harder it is to grasp the task tree.
             task2=TaskD(task1=TaskC(task=TaskA(param='foo')), task2=TaskC(task=TaskB(task=TaskA(param='bar'))))   # same task
         )
     )
-    print(gokart.make_tree_info(task))
+    print(gokart.make_tree_info_string(task))
 
 
 .. code:: sh
@@ -125,12 +125,12 @@ The more dependencies you have, the harder it is to grasp the task tree.
             └─- ...
 
 
-In task dependency tree output by `make_tree_info`, the sub-trees already shown in above will be omitted.
+In task dependency tree output by `make_tree_info_string`, the sub-trees already shown in above will be omitted.
 We can disable this omission by passing ``False`` to ``abbr`` flag:
 
 .. code:: python
 
-    print(make_tree_info(task, abbr=False))
+    print(make_tree_info_string(task, abbr=False))
 
 
 

--- a/gokart/__init__.py
+++ b/gokart/__init__.py
@@ -1,5 +1,6 @@
 from gokart.build import build
 from gokart.info import make_tree_info, tree_info
+from gokart.tree.task_info import make_tree_info_string
 from gokart.pandas_type_config import PandasTypeConfig
 from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.run import run

--- a/gokart/__init__.py
+++ b/gokart/__init__.py
@@ -1,10 +1,10 @@
 from gokart.build import build
 from gokart.info import make_tree_info, tree_info
-from gokart.tree.task_info import make_tree_info_string
 from gokart.pandas_type_config import PandasTypeConfig
 from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.run import run
 from gokart.task import TaskOnKart
 from gokart.testing import test_run
+from gokart.tree.task_info import make_tree_info_string
 from gokart.utils import add_config
 from gokart.workspace_management import delete_local_unnecessary_outputs

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -10,12 +10,33 @@ from gokart.tree.task_info import make_tree_info_string
 logger = getLogger(__name__)
 
 
-def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited_tasks=None, ignore_task_names=None):
+def make_tree_info(task: TaskOnKart,
+                   indent: str = '',
+                   last: bool = True,
+                   details: bool = False,
+                   abbr: bool = True,
+                   visited_tasks: Optional[Set[str]] = None,
+                   ignore_task_names: Optional[List[str]] = None) -> str:
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
 
     This function has moved to `gokart.tree.task_info.make_tree_info_string`.
     This code is remained for backward compatibility.
+
+    Parameters
+    ----------
+    - task: TaskOnKart
+        Root task.
+    - details: bool
+        Whether or not to output details.
+    - abbr: bool
+        Whether or not to simplify tasks information that has already appeared.
+    - ignore_task_names: Optional[List[str]]
+        List of task names to ignore.
+    Returns
+    -------
+    - tree_info : str
+        Formatted task dependency tree.
     """
     return make_tree_info_string(task=task, details=details, abbr=abbr, ignore_task_names=ignore_task_names)
 

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -1,21 +1,73 @@
 import warnings
 from logging import getLogger
+from typing import List, NamedTuple, Optional, Set, Tuple
 
 import luigi
 
+from gokart.target import TargetOnKart
 from gokart.task import TaskOnKart
 
 logger = getLogger(__name__)
 
 
-def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited_tasks=None):
-    """
-    Return a string representation of the tasks, their statuses/parameters in a dependency tree format
-    """
+class TaskInfo(NamedTuple):
+    name: str
+    unique_id: str
+    path: List[TargetOnKart]
+    params: dict
+    processing_time: str
+    is_complete: str
+    task_log: dict
+
+
+class TaskTree:
+    def __init__(self, task_info: TaskInfo, children_task_trees: Tuple) -> None:
+        self.task_info: TaskInfo = task_info
+        self.children_task_trees: Tuple = children_task_trees
+
+    def get_task_id(self):
+        return f'{self.task_info.name}_{self.task_info.unique_id}'
+
+    def get_task_title(self):
+        return f'({self.task_info.is_complete}) {self.task_info.name}[{self.task_info.unique_id}]'
+
+    def get_task_detail(self):
+        return f'(parameter={self.task_info.params}, output={self.task_info.path}, time={self.task_info.processing_time}, task_log={self.task_info.task_log})'
+
+
+def _make_task_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]) -> TaskTree:
     with warnings.catch_warnings():
         warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
         is_task_complete = task.complete()
     is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
+    name = task.__class__.__name__
+    params = task.get_info(only_significant=True)
+    output_paths = [t.path() for t in luigi.task.flatten(task.output())]
+    processing_time = task.get_processing_time()
+    if type(processing_time) == float:
+        processing_time = str(processing_time) + 's'
+    task_log = dict(task.get_task_log())
+
+    task_info = TaskInfo(
+        name=name,
+        unique_id=task.make_unique_id(),
+        path=output_paths,
+        params=params,
+        processing_time=processing_time,
+        is_complete=is_complete,
+        task_log=task_log,
+    )
+
+    children = luigi.task.flatten(task.requires())
+    children_task_trees_list: List[TaskTree] = []
+    for child in children:
+        if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
+            children_task_trees_list.append(_make_task_tree(child, ignore_task_names=ignore_task_names))
+    children_task_trees = tuple(children_task_trees_list)
+    return TaskTree(task_info=task_info, children_task_trees=children_task_trees)
+
+
+def _make_tree_info(task_tree: TaskTree, indent: str = '', last: bool = True, details: bool = False, abbr: bool = True, visited_tasks: Set[str] = None):
     result = '\n' + indent
     if last:
         result += '└─-'
@@ -23,12 +75,11 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited
     else:
         result += '|--'
         indent += '|  '
-    name = task.__class__.__name__
-    result += f'({is_complete}) {name}[{task.make_unique_id()}]'
+    result += task_tree.get_task_title()
 
     if abbr:
         visited_tasks = visited_tasks or set()
-        task_id = f'{name}_{task.make_unique_id()}'
+        task_id = task_tree.get_task_id()
         if task_id not in visited_tasks:
             visited_tasks.add(task_id)
         else:
@@ -36,16 +87,20 @@ def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited
             return result
 
     if details:
-        params = task.get_info(only_significant=True)
-        output_paths = [t.path() for t in luigi.task.flatten(task.output())]
-        processing_time = task.get_processing_time()
-        if type(processing_time) == float:
-            processing_time = str(processing_time) + 's'
-        result += f'(parameter={params}, output={output_paths}, time={processing_time}, task_log={dict(task.get_task_log())})'
+        result += task_tree.get_task_detail()
 
-    children = luigi.task.flatten(task.requires())
-    for index, child in enumerate(children):
-        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, visited_tasks=visited_tasks)
+    children = task_tree.children_task_trees
+    for index, child_tree in enumerate(children):
+        result += _make_tree_info(child_tree, indent, (index + 1) == len(children), details=details, abbr=abbr, visited_tasks=visited_tasks)
+    return result
+
+
+def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited_tasks=None, ignore_task_names=None):
+    """
+    Return a string representation of the tasks, their statuses/parameters in a dependency tree format
+    """
+    task_tree = _make_task_tree(task, ignore_task_names=ignore_task_names)
+    result = _make_tree_info(task_tree=task_tree, indent=indent, last=last, details=details, abbr=abbr, visited_tasks=visited_tasks)
     return result
 
 

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -4,104 +4,20 @@ from typing import List, NamedTuple, Optional, Set, Tuple
 
 import luigi
 
-from gokart.target import TargetOnKart
 from gokart.task import TaskOnKart
+from gokart.tree.task_info import make_tree_info_string
 
 logger = getLogger(__name__)
-
-
-class TaskInfo(NamedTuple):
-    name: str
-    unique_id: str
-    path: List[TargetOnKart]
-    params: dict
-    processing_time: str
-    is_complete: str
-    task_log: dict
-
-
-class TaskTree:
-    def __init__(self, task_info: TaskInfo, children_task_trees: Tuple) -> None:
-        self.task_info: TaskInfo = task_info
-        self.children_task_trees: Tuple = children_task_trees
-
-    def get_task_id(self):
-        return f'{self.task_info.name}_{self.task_info.unique_id}'
-
-    def get_task_title(self):
-        return f'({self.task_info.is_complete}) {self.task_info.name}[{self.task_info.unique_id}]'
-
-    def get_task_detail(self):
-        return f'(parameter={self.task_info.params}, output={self.task_info.path}, time={self.task_info.processing_time}, task_log={self.task_info.task_log})'
-
-
-def _make_task_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]) -> TaskTree:
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
-        is_task_complete = task.complete()
-    is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
-    name = task.__class__.__name__
-    params = task.get_info(only_significant=True)
-    output_paths = [t.path() for t in luigi.task.flatten(task.output())]
-    processing_time = task.get_processing_time()
-    if type(processing_time) == float:
-        processing_time = str(processing_time) + 's'
-    task_log = dict(task.get_task_log())
-
-    task_info = TaskInfo(
-        name=name,
-        unique_id=task.make_unique_id(),
-        path=output_paths,
-        params=params,
-        processing_time=processing_time,
-        is_complete=is_complete,
-        task_log=task_log,
-    )
-
-    children = luigi.task.flatten(task.requires())
-    children_task_trees_list: List[TaskTree] = []
-    for child in children:
-        if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
-            children_task_trees_list.append(_make_task_tree(child, ignore_task_names=ignore_task_names))
-    children_task_trees = tuple(children_task_trees_list)
-    return TaskTree(task_info=task_info, children_task_trees=children_task_trees)
-
-
-def _make_tree_info(task_tree: TaskTree, indent: str = '', last: bool = True, details: bool = False, abbr: bool = True, visited_tasks: Set[str] = None):
-    result = '\n' + indent
-    if last:
-        result += '└─-'
-        indent += '   '
-    else:
-        result += '|--'
-        indent += '|  '
-    result += task_tree.get_task_title()
-
-    if abbr:
-        visited_tasks = visited_tasks or set()
-        task_id = task_tree.get_task_id()
-        if task_id not in visited_tasks:
-            visited_tasks.add(task_id)
-        else:
-            result += f'\n{indent}└─- ...'
-            return result
-
-    if details:
-        result += task_tree.get_task_detail()
-
-    children = task_tree.children_task_trees
-    for index, child_tree in enumerate(children):
-        result += _make_tree_info(child_tree, indent, (index + 1) == len(children), details=details, abbr=abbr, visited_tasks=visited_tasks)
-    return result
 
 
 def make_tree_info(task, indent='', last=True, details=False, abbr=True, visited_tasks=None, ignore_task_names=None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
+
+    This function has moved to `gokart.tree.task_info.make_tree_info_string`.
+    This code is remained for backward compatibility.
     """
-    task_tree = _make_task_tree(task, ignore_task_names=ignore_task_names)
-    result = _make_tree_info(task_tree=task_tree, indent=indent, last=last, details=details, abbr=abbr, visited_tasks=visited_tasks)
-    return result
+    return make_tree_info_string(task=task, details=details, abbr=abbr, ignore_task_names=ignore_task_names)
 
 
 class tree_info(TaskOnKart):

--- a/gokart/tree/task_info.py
+++ b/gokart/tree/task_info.py
@@ -88,6 +88,21 @@ def _make_tree_info(task_info: TaskInfo, indent: str, last: bool, details: bool,
 def make_tree_info_string(task: TaskOnKart, details: bool = False, abbr: bool = True, ignore_task_names: Optional[List[str]] = None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
+
+    Parameters
+    ----------
+    - task: TaskOnKart
+        Root task.
+    - details: bool
+        Whether or not to output details.
+    - abbr: bool
+        Whether or not to simplify tasks information that has already appeared.
+    - ignore_task_names: Optional[List[str]]
+        List of task names to ignore.
+    Returns
+    -------
+    - tree_info : str
+        Formatted task dependency tree.
     """
     task_info = _make_task_info_tree(task, ignore_task_names=ignore_task_names)
     result = _make_tree_info(task_info=task_info, indent='', last=True, details=details, abbr=abbr, visited_tasks=set())

--- a/gokart/tree/task_info.py
+++ b/gokart/tree/task_info.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Set
-from dataclasses import dataclass
 import warnings
+from dataclasses import dataclass
+from typing import List, Optional, Set
 
 import luigi
 

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -1,4 +1,5 @@
 import unittest
+from test.tree.test_task_info import _DoubleLoadSubTask, _SubTask, _Task
 from unittest.mock import patch
 
 import luigi
@@ -7,8 +8,6 @@ from luigi.mock import MockFileSystem, MockTarget
 
 import gokart
 import gokart.info
-
-from test.tree.test_task_info import _Task, _SubTask, _DoubleLoadSubTask
 
 
 class TestInfo(unittest.TestCase):

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -6,9 +6,45 @@ import luigi.mock
 from luigi.mock import MockFileSystem, MockTarget
 
 import gokart
-import gokart.info
+from gokart.tree.task_info import make_tree_info_string
 
-from test.tree.test_task_info import _Task, _SubTask, _DoubleLoadSubTask
+
+class _SubTask(gokart.TaskOnKart):
+    task_namespace = __name__
+    param = luigi.IntParameter()
+
+    def output(self):
+        return self.make_target('sub_task.txt')
+
+    def run(self):
+        self.dump(f'task uid = {self.make_unique_id()}')
+
+
+class _Task(gokart.TaskOnKart):
+    task_namespace = __name__
+    param = luigi.IntParameter(default=10)
+    sub = gokart.TaskInstanceParameter(default=_SubTask(param=20))
+
+    def requires(self):
+        return self.sub
+
+    def output(self):
+        return self.make_target('task.txt')
+
+    def run(self):
+        self.dump(f'task uid = {self.make_unique_id()}')
+
+
+class _DoubleLoadSubTask(gokart.TaskOnKart):
+    task_namespace = __name__
+    sub1 = gokart.TaskInstanceParameter()
+    sub2 = gokart.TaskInstanceParameter()
+
+    def output(self):
+        return self.make_target('sub_task.txt')
+
+    def run(self):
+        self.dump(f'task uid = {self.make_unique_id()}')
 
 
 class TestInfo(unittest.TestCase):
@@ -20,7 +56,7 @@ class TestInfo(unittest.TestCase):
         task = _Task(param=1, sub=_SubTask(param=2))
 
         # check before running
-        tree = gokart.info.make_tree_info(task)
+        tree = make_tree_info_string(task)
         expected = r"""
 └─-\(PENDING\) _Task\[[a-z0-9]*\]
    └─-\(PENDING\) _SubTask\[[a-z0-9]*\]$"""
@@ -32,7 +68,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = gokart.info.make_tree_info(task)
+        tree = make_tree_info_string(task)
         expected = r"""
 └─-\(COMPLETE\) _Task\[[a-z0-9]*\]
    └─-\(COMPLETE\) _SubTask\[[a-z0-9]*\]$"""
@@ -47,7 +83,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = gokart.info.make_tree_info(task)
+        tree = make_tree_info_string(task)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
    \|--\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -65,7 +101,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = gokart.info.make_tree_info(task, abbr=False)
+        tree = make_tree_info_string(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
    \|--\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -83,11 +119,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = gokart.info.make_tree_info(task, abbr=False, ignore_task_names=['_Task'])
+        tree = make_tree_info_string(task, abbr=False, ignore_task_names=['_Task'])
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""
         self.assertRegex(tree, expected)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
As discussed in https://github.com/m3dev/gokart/pull/232#issuecomment-897282110, I've refactored back end script of `make_tree_info` and moved them to `gokart.tree.task_info`.