### PR TITLE
Add dump_task_info_table

### DIFF
--- a/docs/task_information.rst
+++ b/docs/task_information.rst
@@ -170,3 +170,23 @@ the output could be like:
 Delete Unnecessary Output Files
 --------------------------------
 To delete output files which are not necessary to run a task, add option ``--delete-unnecessary-output-files``. This option is supported only when a task outputs files in local storage not S3 for now.
+
+
+Dump TaskInfo Table
+--------------------
+``gokart.tree.task_info.dump_task_info_table()`` will dump table information of dependent tasks as a pandas DataFrame.
+This table contains `task name`, `cache unique id`, `cache file path`, `task parameters`, `task processing time`, `completed flag`, and `task log`.
+
+.. code:: python
+
+    from gokart.tree.task_info import dump_task_info_table
+
+    dump_task_info_table(task, task_info_dump_path, ignore_task_names)
+    # - task: TaskOnKart
+    #     Root task.
+    # - task_info_dump_path: str
+    #     Output target file path. Path destination can be `local`, `S3`, or `GCS`.
+    #     File extension can be any type that gokart file processor accepts, including `csv`, `pickle`, or `txt`.
+    #     See `TaskOnKart.make_target module <https://gokart.readthedocs.io/en/latest/task_on_kart.html#taskonkart-make-target>` for details.
+    # - ignore_task_names: Optional[List[str]]
+    #     List of task names to ignore.

--- a/gokart/__init__.py
+++ b/gokart/__init__.py
@@ -5,6 +5,6 @@ from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, T
 from gokart.run import run
 from gokart.task import TaskOnKart
 from gokart.testing import test_run
-from gokart.tree.task_info import make_tree_info_string
+from gokart.tree.task_info import make_task_info_as_tree_str
 from gokart.utils import add_config
 from gokart.workspace_management import delete_local_unnecessary_outputs

--- a/gokart/info.py
+++ b/gokart/info.py
@@ -5,7 +5,7 @@ from typing import List, NamedTuple, Optional, Set, Tuple
 import luigi
 
 from gokart.task import TaskOnKart
-from gokart.tree.task_info import make_tree_info_string
+from gokart.tree.task_info import make_task_info_as_tree_str
 
 logger = getLogger(__name__)
 
@@ -20,7 +20,7 @@ def make_tree_info(task: TaskOnKart,
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
 
-    This function has moved to `gokart.tree.task_info.make_tree_info_string`.
+    This function has moved to `gokart.tree.task_info.make_task_info_as_tree_str`.
     This code is remained for backward compatibility.
 
     Parameters
@@ -38,7 +38,7 @@ def make_tree_info(task: TaskOnKart,
     - tree_info : str
         Formatted task dependency tree.
     """
-    return make_tree_info_string(task=task, details=details, abbr=abbr, ignore_task_names=ignore_task_names)
+    return make_task_info_as_tree_str(task=task, details=details, abbr=abbr, ignore_task_names=ignore_task_names)
 
 
 class tree_info(TaskOnKart):

--- a/gokart/tree/task_info.py
+++ b/gokart/tree/task_info.py
@@ -10,7 +10,7 @@ from gokart.task import TaskOnKart
 from gokart.tree.task_info_formatter import make_task_info_tree, make_tree_info, make_tree_info_table_list
 
 
-def make_tree_info_string(task: TaskOnKart, details: bool = False, abbr: bool = True, ignore_task_names: Optional[List[str]] = None):
+def make_task_info_as_tree_str(task: TaskOnKart, details: bool = False, abbr: bool = True, ignore_task_names: Optional[List[str]] = None):
     """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
 
@@ -34,6 +34,27 @@ def make_tree_info_string(task: TaskOnKart, details: bool = False, abbr: bool = 
     return result
 
 
+def make_task_info_as_table(task: TaskOnKart, ignore_task_names: Optional[List[str]]):
+    """Return a table containing information about dependent tasks.
+
+    Parameters
+    ----------
+    - task: TaskOnKart
+        Root task.
+    - ignore_task_names: Optional[List[str]]
+        List of task names to ignore.
+    Returns
+    -------
+    - task_info_table : pandas.DataFrame 
+        Formatted task dependency table.
+    """
+
+    task_info = make_task_info_tree(task, ignore_task_names=ignore_task_names)
+    task_info_table = pd.DataFrame(make_tree_info_table_list(task_info=task_info, visited_tasks=set()))
+
+    return task_info_table
+
+
 def dump_task_info_table(task: TaskOnKart, task_info_dump_path: str, ignore_task_names: Optional[List[str]]):
     """Dump a table containing information about dependent tasks.
 
@@ -47,10 +68,12 @@ def dump_task_info_table(task: TaskOnKart, task_info_dump_path: str, ignore_task
         See `TaskOnKart.make_target module <https://gokart.readthedocs.io/en/latest/task_on_kart.html#taskonkart-make-target>` for details.
     - ignore_task_names: Optional[List[str]]
         List of task names to ignore.
+    Returns
+    -------
+    None
     """
-    task_info = make_task_info_tree(task, ignore_task_names=ignore_task_names)
+    task_info_table = make_task_info_as_table(task=task, ignore_task_names=ignore_task_names)
 
-    task_info_table = pd.DataFrame(make_tree_info_table_list(task_info=task_info, visited_tasks=set()))
     unique_id = task.make_unique_id()
 
     task_info_target = make_target(file_path=task_info_dump_path, unique_id=unique_id)

--- a/gokart/tree/task_info.py
+++ b/gokart/tree/task_info.py
@@ -129,8 +129,7 @@ def _make_tree_info_table_list(task_info: TaskInfo, visited_tasks: Set[str]):
     result = [task_info.task_info_dict()]
 
     children = task_info.children_task_infos
-    for child in children:
-        result += _make_tree_info_table_list(task_info=child, visited_tasks=visited_tasks)
+    result += list(itertools.chain.from_iterable(_make_tree_info_table_list(task_info=child, visited_tasks=visited_tasks) for child in children))
     return result
 
 

--- a/gokart/tree/task_info.py
+++ b/gokart/tree/task_info.py
@@ -120,6 +120,19 @@ def _make_tree_info_table_list(task_info: TaskInfo, visited_tasks: Set[str]):
 
 
 def dump_task_info_table(task: TaskOnKart, task_info_dump_path: str, ignore_task_names: Optional[List[str]]):
+    """Dump a table containing information about dependent tasks.
+
+    Parameters
+    ----------
+    - task: TaskOnKart
+        Root task.
+    - task_info_dump_path: str
+        Output target file path. Path destination can be `local`, `S3`, or `GCS`.
+        File extension can be any type that gokart file processor accepts, including `csv`, `pickle`, or `txt`.
+        See `TaskOnKart.make_target module <https://gokart.readthedocs.io/en/latest/task_on_kart.html#taskonkart-make-target>` for details.
+    - ignore_task_names: Optional[List[str]]
+        List of task names to ignore.
+    """
     task_info = _make_task_info_tree(task, ignore_task_names=ignore_task_names)
 
     task_info_table = pd.DataFrame(_make_tree_info_table_list(task_info=task_info, visited_tasks=set()))

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -1,0 +1,110 @@
+import warnings
+from dataclasses import dataclass
+from typing import List, Optional, Set
+
+import luigi
+import pandas as pd
+
+from gokart.target import make_target
+from gokart.task import TaskOnKart
+
+
+@dataclass
+class TaskInfo:
+    name: str
+    unique_id: str
+    output_paths: List[TaskOnKart]
+    params: dict
+    processing_time: str
+    is_complete: str
+    task_log: dict
+    children_task_infos: List['TaskInfo']
+
+    def get_task_id(self):
+        return f'{self.name}_{self.unique_id}'
+
+    def get_task_title(self):
+        return f'({self.is_complete}) {self.name}[{self.unique_id}]'
+
+    def get_task_detail(self):
+        return f'(parameter={self.params}, output={self.output_paths}, time={self.processing_time}, task_log={self.task_log})'
+
+    def task_info_dict(self):
+        return dict(name=self.name,
+                    unique_id=self.unique_id,
+                    output_paths=self.output_paths,
+                    params=self.params,
+                    processing_time=self.processing_time,
+                    is_complete=self.is_complete,
+                    task_log=self.task_log)
+
+
+def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]) -> TaskInfo:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
+        is_task_complete = task.complete()
+
+    name = task.__class__.__name__
+    unique_id = task.make_unique_id()
+    output_paths = [t.path() for t in luigi.task.flatten(task.output())]
+    params = task.get_info(only_significant=True)
+    processing_time = task.get_processing_time()
+    if type(processing_time) == float:
+        processing_time = str(processing_time) + 's'
+    is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
+    task_log = dict(task.get_task_log())
+
+    children = luigi.task.flatten(task.requires())
+    children_task_infos: List[TaskInfo] = []
+    for child in children:
+        if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
+            children_task_infos.append(make_task_info_tree(child, ignore_task_names=ignore_task_names))
+    return TaskInfo(name=name,
+                    unique_id=unique_id,
+                    output_paths=output_paths,
+                    params=params,
+                    processing_time=processing_time,
+                    is_complete=is_complete,
+                    task_log=task_log,
+                    children_task_infos=children_task_infos)
+
+
+def make_tree_info(task_info: TaskInfo, indent: str, last: bool, details: bool, abbr: bool, visited_tasks: Set[str]):
+    result = '\n' + indent
+    if last:
+        result += '└─-'
+        indent += '   '
+    else:
+        result += '|--'
+        indent += '|  '
+    result += task_info.get_task_title()
+
+    if abbr:
+        task_id = task_info.get_task_id()
+        if task_id not in visited_tasks:
+            visited_tasks.add(task_id)
+        else:
+            result += f'\n{indent}└─- ...'
+            return result
+
+    if details:
+        result += task_info.get_task_detail()
+
+    children = task_info.children_task_infos
+    for index, child in enumerate(children):
+        result += make_tree_info(child, indent, (index + 1) == len(children), details=details, abbr=abbr, visited_tasks=visited_tasks)
+    return result
+
+
+def make_tree_info_table_list(task_info: TaskInfo, visited_tasks: Set[str]):
+    task_id = task_info.get_task_id()
+    if task_id in visited_tasks:
+        return []
+    visited_tasks.add(task_id)
+
+    result = [task_info.task_info_dict()]
+
+    children = task_info.children_task_infos
+    for child in children:
+        result += make_tree_info_table_list(task_info=child, visited_tasks=visited_tasks)
+    return result

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -1,9 +1,9 @@
 import unittest
 from unittest.mock import patch
 
-import pandas as pd
 import luigi
 import luigi.mock
+import pandas as pd
 from luigi.mock import MockFileSystem, MockTarget
 
 import gokart

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -127,14 +127,16 @@ class TestInfo(unittest.TestCase):
 
 
 class _TaskInfoExampleTaskA(gokart.TaskOnKart):
-    pass
+    task_namespace = __name__
 
 
 class _TaskInfoExampleTaskB(gokart.TaskOnKart):
-    pass
+    task_namespace = __name__
 
 
 class _TaskInfoExampleTaskC(gokart.TaskOnKart):
+    task_namespace = __name__
+
     def requires(self):
         return dict(taskA=_TaskInfoExampleTaskA(), taskB=_TaskInfoExampleTaskB())
 

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -7,7 +7,7 @@ import pandas as pd
 from luigi.mock import MockFileSystem, MockTarget
 
 import gokart
-from gokart.tree.task_info import dump_task_info_table, make_tree_info_string
+from gokart.tree.task_info import dump_task_info_table, make_task_info_as_tree_str
 
 
 class _SubTask(gokart.TaskOnKart):
@@ -57,7 +57,7 @@ class TestInfo(unittest.TestCase):
         task = _Task(param=1, sub=_SubTask(param=2))
 
         # check before running
-        tree = make_tree_info_string(task)
+        tree = make_task_info_as_tree_str(task)
         expected = r"""
 └─-\(PENDING\) _Task\[[a-z0-9]*\]
    └─-\(PENDING\) _SubTask\[[a-z0-9]*\]$"""
@@ -69,7 +69,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = make_tree_info_string(task)
+        tree = make_task_info_as_tree_str(task)
         expected = r"""
 └─-\(COMPLETE\) _Task\[[a-z0-9]*\]
    └─-\(COMPLETE\) _SubTask\[[a-z0-9]*\]$"""
@@ -84,7 +84,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = make_tree_info_string(task)
+        tree = make_task_info_as_tree_str(task)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
    \|--\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -102,7 +102,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = make_tree_info_string(task, abbr=False)
+        tree = make_task_info_as_tree_str(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
    \|--\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -120,7 +120,7 @@ class TestInfo(unittest.TestCase):
 
         # check after sub task runs
         luigi.build([task], local_scheduler=True)
-        tree = make_tree_info_string(task, abbr=False, ignore_task_names=['_Task'])
+        tree = make_task_info_as_tree_str(task, abbr=False, ignore_task_names=['_Task'])
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""
         self.assertRegex(tree, expected)


### PR DESCRIPTION
I've added new function `gokart.tree.task_info.dump_task_info_table()` which dumps tasks information as a pandas.DataFrame.

Issue: https://github.com/m3dev/gokart/issues/231