### PR TITLE
change default loglevel of gokart.build as ERROR

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -10,7 +10,7 @@ from gokart.utils import check_config, read_environ
 
 
 class LoggerConfig:
-    def __init__(self, level: int = logging.CRITICAL):
+    def __init__(self, level: int):
         self.logger = getLogger(__name__)
         self.default_level = self.logger.level
         self.level = level
@@ -43,7 +43,7 @@ def _reset_register(keep={'gokart', 'luigi'}):
                                          if x.__module__.split('.')[0] in keep]  # avoid TaskClassAmbigiousException
 
 
-def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = True, log_level: int = logging.CRITICAL) -> Optional[Any]:
+def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = True, log_level: int = logging.ERROR) -> Optional[Any]:
     """
     Run gokart task for local interpreter.
     """


### PR DESCRIPTION
As issued in #211 , gokart was hard to debug because of less fexible logging.
With #212 log_level arg is introduced in gokart.build .
In this PR, I suggest changing default value of this log_level arg.

Of course I know there might be discussion about pros/cons of lower loglevel.
But I believe following drawback is critical one especially for first-time user of gokart.

# Problem

The major drawback of suppressing logs are that we can't see traceback of failed tasks
(So we need to run tasks again with lower loglevel after facing failed tasks)

```python
class Task(gokart.TaskOnKart):
    def run(self):
        raise Exception()
gokart.build(Task(), log_level=logging.CRITICAL)
```

```
GokartBuildError:
===== Luigi Execution Summary =====

Scheduled 1 tasks of which:
* 1 failed:
- 1 Task(...)

This progress looks :( because there were failed tasks

===== Luigi Execution Summary =====
---------------------------------------------------------------------------
GokartBuildError                          Traceback (most recent call last)
...
```

# Solution?

With log_level=ERROR,

```python
gokart.build(Task(), log_level=logging.ERROR)
```

we can see more comprehensive messages.

```
ERROR: [pid 7101] Worker Worker(salt=857636714, workers=1, host=m3-2019mac58, username=keisuke.ogaki, pid=7101) failed    Task()
Traceback (most recent call last):
  File "/Users/keisuke.ogaki/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/luigi/worker.py", line 191, in run
    new_deps = self._run_get_new_deps()
  File "/Users/keisuke.ogaki/.pyenv/versions/anaconda3-5.3.1/lib/python3.7/site-packages/luigi/worker.py", line 133, in _run_get_new_deps
    task_gen = self.task.run()
  File "<ipython-input-5-8523995f898f>", line 3, in run
    raise Exception()
Exception
GokartBuildError:
===== Luigi Execution Summary =====

Scheduled 1 tasks of which:
* 1 failed:
- 1 Task(...)

This progress looks :( because there were failed tasks

===== Luigi Execution Summary =====
---------------------------------------------------------------------------
GokartBuildError                          Traceback (most recent call last)
...
```