### PR TITLE
Add requires to TaskInfo

### DIFF
--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -1,3 +1,4 @@
+from gokart.tree.task_info_formatter import RequiredTask
 import unittest
 from unittest.mock import patch
 
@@ -156,7 +157,8 @@ class TestTaskInfoTable(unittest.TestCase):
             dump_task_info_table(task=_TaskInfoExampleTaskC(), task_info_dump_path='path.csv', ignore_task_names=['_TaskInfoExampleTaskB'])
 
             self.assertEqual(set(self.dumped_data['name']), {'_TaskInfoExampleTaskA', '_TaskInfoExampleTaskC'})
-            self.assertEqual(set(self.dumped_data.columns), {'name', 'unique_id', 'output_paths', 'params', 'processing_time', 'is_complete', 'task_log'})
+            self.assertEqual(set(self.dumped_data.columns),
+                             {'name', 'unique_id', 'output_paths', 'params', 'processing_time', 'is_complete', 'task_log', 'requires'})
 
 
 class TestTaskInfoTree(unittest.TestCase):
@@ -172,6 +174,10 @@ class TestTaskInfoTree(unittest.TestCase):
 
             self.assertEqual(self.dumped_data.name, '_TaskInfoExampleTaskC')
             self.assertEqual(self.dumped_data.children_task_infos[0].name, '_TaskInfoExampleTaskA')
+
+            self.assertEqual(self.dumped_data.requires.keys(), {'taskA', 'taskB'})
+            self.assertEqual(self.dumped_data.requires['taskA'].name, '_TaskInfoExampleTaskA')
+            self.assertEqual(self.dumped_data.requires['taskB'].name, '_TaskInfoExampleTaskB')
 
     def test_dump_task_info_tree_with_invalid_path_extention(self):
         with patch('gokart.target.SingleFileTarget.dump') as mock_obj:

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -1,10 +1,8 @@
-from gokart.tree.task_info_formatter import RequiredTask
 import unittest
 from unittest.mock import patch
 
 import luigi
 import luigi.mock
-import pandas as pd
 from luigi.mock import MockFileSystem, MockTarget
 
 import gokart

--- a/test/tree/test_task_info_formatter.py
+++ b/test/tree/test_task_info_formatter.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+import luigi.mock
+import pandas as pd
+from luigi.mock import MockFileSystem, MockTarget
+
+import gokart
+from gokart.tree.task_info_formatter import RequiredTask, _make_requires_info
+
+
+class _RequiredTaskExampleTaskA(gokart.TaskOnKart):
+    task_namespace = __name__
+
+
+class TestMakeRequiresInfo(unittest.TestCase):
+    def test_make_requires_info_with_task_on_kart(self):
+        requires = _RequiredTaskExampleTaskA()
+        resulted = _make_requires_info(requires=requires)
+        expected = RequiredTask(name=requires.__class__.__name__, unique_id=requires.make_unique_id())
+        self.assertEqual(resulted, expected)
+
+    def test_make_requires_info_with_list(self):
+        requires = [_RequiredTaskExampleTaskA()]
+        resulted = _make_requires_info(requires=requires)
+        expected = [RequiredTask(name=require.__class__.__name__, unique_id=require.make_unique_id()) for require in requires]
+        self.assertEqual(resulted, expected)
+
+    def test_make_requires_info_with_dict(self):
+        requires = dict(taskA=_RequiredTaskExampleTaskA())
+        resulted = _make_requires_info(requires=requires)
+        expected = {key: RequiredTask(name=require.__class__.__name__, unique_id=require.make_unique_id()) for key, require in requires.items()}
+        self.assertEqual(resulted, expected)
+
+    def test_make_requires_info_with_invalid(self):
+        requires = pd.DataFrame()
+        with self.assertRaises(TypeError):
+            _make_requires_info(requires=requires)

--- a/test/tree/test_task_info_formatter.py
+++ b/test/tree/test_task_info_formatter.py
@@ -1,9 +1,6 @@
 import unittest
-from unittest.mock import patch
 
-import luigi.mock
 import pandas as pd
-from luigi.mock import MockFileSystem, MockTarget
 
 import gokart
 from gokart.tree.task_info_formatter import RequiredTask, _make_requires_info


### PR DESCRIPTION
I've added `requires` attribute to `TaskInfo`, so that information of `task.requires()` will be dumped to tree_info_table.

This is useful when a task requires 2 same tasks but with different parameter.
With key as index, you can get the unique_id of the two tasks separately.


```python
class _TaskInfoExampleTaskA(gokart.TaskOnKart):
    def requires(self):
        return dict(task1=_TaskInfoExampleTaskA(param=1), task2=_TaskInfoExampleTaskA(param=2))
```

In the above example, the requires column of tree_info_table will have dictionary with same keys as return() (i.e. task1, task2) and object of name and unique_id (i.e. RequiredTask(name, unique_id) object) as values.
In this way, we can distinguish between two tasks by key and get the unique_id.

Please review.