### PR TITLE
fix issue #254

### DIFF
--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -24,7 +24,7 @@ class TaskInstanceParameter(luigi.Parameter):
                 s = bz2.decompress(bytes.fromhex(s)).decode()
             except Exception as e:
                 logger.debug(f'[Exception] {e} by {s}')
-            s = luigi.dictparameter().parse(s)
+            s = luigi.DictParameter().parse(s)
         return self._recursive(s)
 
     def serialize(self, x):

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -18,10 +18,11 @@ class TaskInstanceParameter(luigi.Parameter):
                 params[key] = value.parse(params[key])
         return task_cls(**params)
 
+    @staticmethod
     def _recursive_decompress(self, s):
         s = dict(luigi.DictParameter().parse(s))
         if 'params' in s:
-            s['params'] = self._recursive_decompress(bz2.decompress(bytes.fromhex(s['params'])).decode())
+            s['params'] = TaskInstanceParameter._recursive_decompress(bz2.decompress(bytes.fromhex(s['params'])).decode())
         return s
 
     def parse(self, s):

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -17,13 +17,11 @@ class TaskInstanceParameter(luigi.Parameter):
 
     def parse(self, s):
         if isinstance(s, str):
-            s = luigi.DictParameter().parse(
-                bz2.decompress(bytes.fromhex(s)).decode())
+            s = luigi.DictParameter().parse(bz2.decompress(bytes.fromhex(s)).decode())
         return self._recursive(s)
 
     def serialize(self, x):
-        params = bz2.compress(
-            str(x.to_str_params(only_significant=True)).encode()).hex()
+        params = bz2.compress(str(x.to_str_params(only_significant=True)).encode()).hex()
         values = dict(type=x.get_task_family(), params=params)
         return luigi.DictParameter().serialize(values)
 

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -1,8 +1,11 @@
 import bz2
 import json
+from logging import getLogger
 
 import luigi
 from luigi import task_register
+
+logger = getLogger(__name__)
 
 
 class TaskInstanceParameter(luigi.Parameter):
@@ -17,7 +20,11 @@ class TaskInstanceParameter(luigi.Parameter):
 
     def parse(self, s):
         if isinstance(s, str):
-            s = luigi.DictParameter().parse(bz2.decompress(bytes.fromhex(s)).decode())
+            try:
+                s = bz2.decompress(bytes.fromhex(s)).decode()
+            except Exception as e:
+                logger.debug(f'[Exception] {e} by {s}')
+            s = luigi.dictparameter().parse(s)
         return self._recursive(s)
 
     def serialize(self, x):

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -1,5 +1,5 @@
-import json
 import bz2
+import json
 
 import luigi
 from luigi import task_register

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -1,4 +1,5 @@
 import json
+import bz2
 
 import luigi
 from luigi import task_register
@@ -16,11 +17,14 @@ class TaskInstanceParameter(luigi.Parameter):
 
     def parse(self, s):
         if isinstance(s, str):
-            s = luigi.DictParameter().parse(s)
+            s = luigi.DictParameter().parse(
+                bz2.decompress(bytes.fromhex(s)).decode())
         return self._recursive(s)
 
     def serialize(self, x):
-        values = dict(type=x.get_task_family(), params=x.to_str_params(only_significant=True))
+        params = bz2.compress(
+            str(x.to_str_params(only_significant=True)).encode()).hex()
+        values = dict(type=x.get_task_family(), params=params)
         return luigi.DictParameter().serialize(values)
 
 

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -19,7 +19,7 @@ class TaskInstanceParameter(luigi.Parameter):
         return task_cls(**params)
 
     @staticmethod
-    def _recursive_decompress(self, s):
+    def _recursive_decompress(s):
         s = dict(luigi.DictParameter().parse(s))
         if 'params' in s:
             s['params'] = TaskInstanceParameter._recursive_decompress(bz2.decompress(bytes.fromhex(s['params'])).decode())


### PR DESCRIPTION
Hi.
Compressing strings reduces memory usage and allows [sample code](https://github.com/m3dev/gokart/issues/254#issuecomment-953476444) to run.


Please note that this is "quick" solution.
`TaskInstanceParameter.serialize` and `luigi.to_str_params` is used in a variety of ways. And it's recursive.
We will need to cache `input of TaskInstanceParameter.serialize` in the future.