### PR TITLE
Passing additional arguments with gokart.build() (like workers=...)

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -46,6 +46,7 @@ def _reset_register(keep={'gokart', 'luigi'}):
 def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = True, log_level: int = logging.ERROR, **env_params) -> Optional[Any]:
     """
     Run gokart task for local interpreter.
+    Sharing the most of its parameters with luigi.build (see https://luigi.readthedocs.io/en/stable/api/luigi.html?highlight=build#luigi.build)
     """
     if reset_register:
         _reset_register()

--- a/gokart/build.py
+++ b/gokart/build.py
@@ -43,7 +43,7 @@ def _reset_register(keep={'gokart', 'luigi'}):
                                          if x.__module__.split('.')[0] in keep]  # avoid TaskClassAmbigiousException
 
 
-def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = True, log_level: int = logging.ERROR) -> Optional[Any]:
+def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = True, log_level: int = logging.ERROR, **env_params) -> Optional[Any]:
     """
     Run gokart task for local interpreter.
     """
@@ -52,7 +52,7 @@ def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = Tr
     read_environ()
     check_config()
     with LoggerConfig(level=log_level):
-        result = luigi.build([task], local_scheduler=True, detailed_summary=True)
+        result = luigi.build([task], local_scheduler=True, detailed_summary=True, **env_params)
         if result.status == luigi.LuigiStatusCode.FAILED:
             raise GokartBuildError(result.summary_text)
     return _get_output(task) if return_value else None

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -41,6 +41,14 @@ class _DummyFailedTask(gokart.TaskOnKart):
         raise RuntimeError
 
 
+class _ParallelRunner(gokart.TaskOnKart):
+    def requires(self):
+        return [_DummyTask(param=str(i)) for i in range(10)]
+
+    def run(self):
+        self.dump('done')
+
+
 class RunTest(unittest.TestCase):
     def setUp(self):
         luigi.configuration.LuigiConfigParser._instance = None
@@ -56,6 +64,10 @@ class RunTest(unittest.TestCase):
         text = 'test'
         output = gokart.build(_DummyTask(param=text), reset_register=False)
         self.assertEqual(output, text)
+
+    def test_build_parallel(self):
+        output = gokart.build(_ParallelRunner(), reset_register=False, workers=20)
+        self.assertEqual(output, 'done')
 
     def test_read_config(self):
         os.environ.setdefault('test_param', 'test')


### PR DESCRIPTION
Resolves #251 

With this fix, we can pass all the parameters which luigi.build can handle :)