### PR TITLE
Add Error Message

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -297,6 +297,10 @@ class TaskOnKart(luigi.Task):
         def _to_str_params(task):
             if isinstance(task, TaskOnKart):
                 return str(task.make_unique_id()) if task.significant else None
+
+            if not isinstance(task, luigi.Task):
+                raise ValueError(f"Task.requires method returns {type(task)}. You should return some kind of GokartTask.")
+
             return task.to_str_params(only_significant=True)
 
         dependencies = [_to_str_params(task) for task in luigi.task.flatten(self.requires())]

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -299,7 +299,7 @@ class TaskOnKart(luigi.Task):
                 return str(task.make_unique_id()) if task.significant else None
 
             if not isinstance(task, luigi.Task):
-                raise ValueError(f"Task.requires method returns {type(task)}. You should return some kind of GokartTask.")
+                raise ValueError(f"Task.requires method returns {type(task)}. You should return luigi.Task.")
 
             return task.to_str_params(only_significant=True)
 


### PR DESCRIPTION
```
class PipelineTask(GokartTask):
    def requires(self):
        return 1.0
```
requiresメソッドでGokartTaskではない変数を返そうとすると下記のようなエラーメッセージになります。
```
luigi AttributeError: 'float' object has no attribute 'to_str_params'
```
エラーメッセージから原因がわかりずらかったので、「requiresメソッドの返り値がGokartTaskでないよ」という趣旨のValueErrorをraiseするようにしました。