### PR TITLE
replace interpolation for reading only needed environment variables

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 import luigi
 
 from gokart.task import TaskOnKart
-from gokart.utils import check_config, read_environ
+from gokart.utils import check_config, set_environ_interpolation
 
 
 class LoggerConfig:
@@ -51,7 +51,7 @@ def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = Tr
     """
     if reset_register:
         _reset_register()
-    read_environ()
+    set_environ_interpolation()
     check_config()
     with LoggerConfig(level=log_level):
         result = luigi.build([task], local_scheduler=True, detailed_summary=True, **env_params)

--- a/gokart/run.py
+++ b/gokart/run.py
@@ -11,7 +11,7 @@ from luigi.cmdline_parser import CmdlineParser
 import gokart
 import gokart.slack
 from gokart.object_storage import ObjectStorage
-from gokart.utils import check_config, read_environ
+from gokart.utils import check_config, set_environ_interpolation
 
 logger = getLogger(__name__)
 
@@ -90,7 +90,7 @@ def run(cmdline_args=None, set_retcode=True):
         luigi.retcodes.retcode.task_failed = 40
         luigi.retcodes.retcode.scheduling_error = 50
 
-    read_environ()
+    set_environ_interpolation()
     check_config()
     _try_tree_info(cmdline_args)
     _try_to_delete_unnecessary_output_file(cmdline_args)

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -1,14 +1,46 @@
 import configparser
 import os
-from configparser import ConfigParser
+import re
+from configparser import BasicInterpolation, Interpolation
 
 import luigi
+from luigi.configuration.cfg_parser import CombinedInterpolation, EnvironmentInterpolation
 
 
-def read_environ():
+class BasicEnvironmentInterpolation(Interpolation):
+    """
+    Custom interpolation which allows values to refer to environment variables
+    using the ``%(ENVVAR)s`` syntax.
+    Based on luigi.configulation.cfg_parser.EnvironmentInterpolation.
+    """
+    _ENVRE = re.compile(r"%\(([^\)]+)\)s")  # matches "%(envvar)s"
+
+    def before_get(self, parser, section, option, value, defaults):
+        return self._interpolate_env(option, section, value)
+
+    def _interpolate_env(self, option, section, value):
+        parts = []
+        while value:
+            match = self._ENVRE.search(value)
+            if match is None:
+                parts.append(value)
+                break
+            envvar = match.groups()[0]
+            if envvar in os.environ:
+                envval = os.environ[envvar]
+                start, end = match.span()
+                parts.append(value[:start])
+                parts.append(envval)
+                value = value[end:]
+            else:
+                parts.append(value)
+                break
+        return "".join(parts)
+
+
+def set_environ_interpolation():
     config = luigi.configuration.get_config()
-    for key, value in os.environ.items():
-        super(ConfigParser, config).set(section=None, option=key, value=value.replace('%', '%%'))
+    config._interpolation = CombinedInterpolation([BasicEnvironmentInterpolation(), BasicInterpolation(), EnvironmentInterpolation()])
 
 
 def check_config():
@@ -24,4 +56,4 @@ def add_config(file_path: str):
     _, ext = os.path.splitext(file_path)
     luigi.configuration.core.parser = ext
     assert luigi.configuration.add_config_path(file_path)
-    read_environ()
+    set_environ_interpolation()


### PR DESCRIPTION
When I want to use the local stack, I try to specify 'endpoint_url' in the 's3' section, but it fails because `boto3.resources()` reads the environment variable.

The following is an example of a param.ini.
```
[s3]
endpoint_url=http://localhost:4566
```

When I run it in this state, it outputs an error as follows. (`<ENV>` is the environment variable.)
```
[2022/02/01 06:59:38][luigi-interface][ERROR](s3.py:141) resource() got an unexpected keyword argument '<ENV>'
[2022/02/01 06:59:38][luigi-interface][WARNING](worker.py:651) Will not run sample.Sample() or any dependencies due to error in complete() method:
Traceback (most recent call last):
  File "/opt/pysetup/.venv/lib/python3.9/site-packages/luigi/contrib/s3.py", line 135, in s3
  self._s3 = boto3.resource('s3',
  File "/opt/pysetup/.venv/lib/python3.9/site-packages/boto3/__init__.py", line 102, in resource
     return _get_default_session().resource(*args, **kwargs)
TypeError: resource() got an unexpected keyword argument '<ENV>'
```

This is because ConfigParser reads all environment variables with `read_environ()` in utils.py.

# Suggestion

I created this PR as the first idea for this measure.
My proposed change overrides the Interpolation in luigi's ConfigParser and expands the environment variables denoted by `%()s` first.
I abolished `read_environ()` and applied the `BasicEnvironmentInterpolation` to ConfigParser in `set_environ_interpolation()`.

Alternatively, I would suggest doing away with `read_environ()` and only using  luigi's style`${ENVVAR}`.
Please review!