### PR TITLE
Bugfix: task_info should accept generator

### DIFF
--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -1,11 +1,10 @@
+import typing
 import warnings
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Optional, Set, Union
+from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Union
 
 import luigi
-import pandas as pd
 
-from gokart.target import make_target
 from gokart.task import TaskOnKart
 
 
@@ -49,14 +48,12 @@ class RequiredTask(NamedTuple):
 def _make_requires_info(requires):
     if isinstance(requires, TaskOnKart):
         return RequiredTask(name=requires.__class__.__name__, unique_id=requires.make_unique_id())
-
-    if isinstance(requires, list) or isinstance(requires, tuple):
+    elif isinstance(requires, dict):
+        return {key: _make_requires_info(requires=item) for key, item in requires.items()}
+    elif isinstance(requires, typing.Iterable):
         return [_make_requires_info(requires=item) for item in requires]
 
-    if isinstance(requires, dict):
-        return {key: _make_requires_info(requires=item) for key, item in requires.items()}
-
-    raise TypeError(f'`requires` has unexpected type {type(requires)}. Must be `TaskOnKart`, `List[TaskOnKart]`, or `Dict[str, TaskOnKart]`')
+    raise TypeError(f'`requires` has unexpected type {type(requires)}. Must be `TaskOnKart`, `Iterarble[TaskOnKart]`, or `Dict[str, TaskOnKart]`')
 
 
 def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:

--- a/test/tree/test_task_info_formatter.py
+++ b/test/tree/test_task_info_formatter.py
@@ -24,6 +24,12 @@ class TestMakeRequiresInfo(unittest.TestCase):
         expected = [RequiredTask(name=require.__class__.__name__, unique_id=require.make_unique_id()) for require in requires]
         self.assertEqual(resulted, expected)
 
+    def test_make_requires_info_with_generator(self):
+        requires = (_RequiredTaskExampleTaskA() for _ in range(2))
+        resulted = _make_requires_info(requires=requires)
+        expected = [RequiredTask(name=require.__class__.__name__, unique_id=require.make_unique_id()) for require in requires]
+        self.assertEqual(resulted, expected)
+
     def test_make_requires_info_with_dict(self):
         requires = dict(taskA=_RequiredTaskExampleTaskA())
         resulted = _make_requires_info(requires=requires)

--- a/test/tree/test_task_info_formatter.py
+++ b/test/tree/test_task_info_formatter.py
@@ -25,9 +25,9 @@ class TestMakeRequiresInfo(unittest.TestCase):
         self.assertEqual(resulted, expected)
 
     def test_make_requires_info_with_generator(self):
-        requires = (_RequiredTaskExampleTaskA() for _ in range(2))
-        resulted = _make_requires_info(requires=requires)
-        expected = [RequiredTask(name=require.__class__.__name__, unique_id=require.make_unique_id()) for require in requires]
+        requires_gen = lambda: (_RequiredTaskExampleTaskA() for _ in range(2))
+        resulted = _make_requires_info(requires=requires_gen())
+        expected = [RequiredTask(name=require.__class__.__name__, unique_id=require.make_unique_id()) for require in requires_gen()]
         self.assertEqual(resulted, expected)
 
     def test_make_requires_info_with_dict(self):
@@ -37,6 +37,6 @@ class TestMakeRequiresInfo(unittest.TestCase):
         self.assertEqual(resulted, expected)
 
     def test_make_requires_info_with_invalid(self):
-        requires = pd.DataFrame()
+        requires = [1, 2]
         with self.assertRaises(TypeError):
             _make_requires_info(requires=requires)


### PR DESCRIPTION
solves #278 

TaskOnKart.requires() can be written as generator


```
Task:
  def requires():
     for ... in ...:
        yield SubTas()
```

but task_info_formatter is too strict `requires()` to be `List` or `Tuple`.

This PR loosen the constraint to request `typing.Iterable`.