### PR TITLE
Use cache in make task info

### DIFF
--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -56,47 +56,45 @@ def _make_requires_info(requires):
     raise TypeError(f'`requires` has unexpected type {type(requires)}. Must be `TaskOnKart`, `Iterarble[TaskOnKart]`, or `Dict[str, TaskOnKart]`')
 
 
-def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:
-    cache = {}
+def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None, cache: Optional[Dict[str, TaskInfo]] = None) -> TaskInfo:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
+        is_task_complete = task.complete()
 
-    def _make_task_info_tree_with_cache(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
-            is_task_complete = task.complete()
+    name = task.__class__.__name__
+    unique_id = task.make_unique_id()
+    output_paths = [t.path() for t in luigi.task.flatten(task.output())]
 
-        name = task.__class__.__name__
-        unique_id = task.make_unique_id()
-        output_paths = [t.path() for t in luigi.task.flatten(task.output())]
 
-        cache_id = f'{name}_{unique_id}_{is_task_complete}'
-        if cache_id in cache:
-            return cache[cache_id]
+    cache = {} if cache is None else cache
+    cache_id = f'{name}_{unique_id}_{is_task_complete}'
+    if cache_id in cache:
+        return cache[cache_id]
 
-        params = task.get_info(only_significant=True)
-        processing_time = task.get_processing_time()
-        if type(processing_time) == float:
-            processing_time = str(processing_time) + 's'
-        is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
-        task_log = dict(task.get_task_log())
-        requires = _make_requires_info(task.requires())
+    params = task.get_info(only_significant=True)
+    processing_time = task.get_processing_time()
+    if type(processing_time) == float:
+        processing_time = str(processing_time) + 's'
+    is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
+    task_log = dict(task.get_task_log())
+    requires = _make_requires_info(task.requires())
 
-        children = luigi.task.flatten(task.requires())
-        children_task_infos: List[TaskInfo] = []
-        for child in children:
-            if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
-                children_task_infos.append(_make_task_info_tree_with_cache(child, ignore_task_names=ignore_task_names))
-        task_info = TaskInfo(name=name,
-                             unique_id=unique_id,
-                             output_paths=output_paths,
-                             params=params,
-                             processing_time=processing_time,
-                             is_complete=is_complete,
-                             task_log=task_log,
-                             requires=requires,
-                             children_task_infos=children_task_infos)
-        cache[cache_id] = task_info
-        return task_info
-    return _make_task_info_tree_with_cache(task, ignore_task_names)
+    children = luigi.task.flatten(task.requires())
+    children_task_infos: List[TaskInfo] = []
+    for child in children:
+        if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
+            children_task_infos.append(make_task_info_tree(child, ignore_task_names=ignore_task_names, cache=cache))
+    task_info = TaskInfo(name=name,
+                            unique_id=unique_id,
+                            output_paths=output_paths,
+                            params=params,
+                            processing_time=processing_time,
+                            is_complete=is_complete,
+                            task_log=task_log,
+                            requires=requires,
+                            children_task_infos=children_task_infos)
+    cache[cache_id] = task_info
+    return task_info
 
 
 def make_tree_info(task_info: TaskInfo, indent: str, last: bool, details: bool, abbr: bool, visited_tasks: Set[str]):

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -1,5 +1,4 @@
 import typing
-from functools import lru_cache
 import warnings
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Union
@@ -57,20 +56,25 @@ def _make_requires_info(requires):
     raise TypeError(f'`requires` has unexpected type {type(requires)}. Must be `TaskOnKart`, `Iterarble[TaskOnKart]`, or `Dict[str, TaskOnKart]`')
 
 
-@lru_cache(maxsize=None)
-def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:
+def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None, cache: Optional[Dict[str, TaskInfo]] = None) -> TaskInfo:
     with warnings.catch_warnings():
         warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
         is_task_complete = task.complete()
 
     name = task.__class__.__name__
     unique_id = task.make_unique_id()
+    is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
+
+    cache = cache or {}
+    cache_id = f'{name}_{unique_id}_{is_complete}'
+    if cache_id in cache:
+        return cache[cache_id]
+
     output_paths = [t.path() for t in luigi.task.flatten(task.output())]
     params = task.get_info(only_significant=True)
     processing_time = task.get_processing_time()
     if type(processing_time) == float:
         processing_time = str(processing_time) + 's'
-    is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
     task_log = dict(task.get_task_log())
     requires = _make_requires_info(task.requires())
 
@@ -78,16 +82,20 @@ def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]
     children_task_infos: List[TaskInfo] = []
     for child in children:
         if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
-            children_task_infos.append(make_task_info_tree(child, ignore_task_names=ignore_task_names))
-    return TaskInfo(name=name,
-                    unique_id=unique_id,
-                    output_paths=output_paths,
-                    params=params,
-                    processing_time=processing_time,
-                    is_complete=is_complete,
-                    task_log=task_log,
-                    requires=requires,
-                    children_task_infos=children_task_infos)
+            children_task_infos.append(make_task_info_tree(child, ignore_task_names=ignore_task_names, cache=cache))
+
+    task_info =  TaskInfo(name=name,
+                          unique_id=unique_id,
+                          output_paths=output_paths,
+                          params=params,
+                          processing_time=processing_time,
+                          is_complete=is_complete,
+                          task_log=task_log,
+                          requires=requires,
+                          children_task_infos=children_task_infos)
+    cache[cache_id] = task_info
+
+    return task_info
 
 
 def make_tree_info(task_info: TaskInfo, indent: str, last: bool, details: bool, abbr: bool, visited_tasks: Set[str]):

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -56,46 +56,47 @@ def _make_requires_info(requires):
     raise TypeError(f'`requires` has unexpected type {type(requires)}. Must be `TaskOnKart`, `Iterarble[TaskOnKart]`, or `Dict[str, TaskOnKart]`')
 
 
-def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None, cache: Optional[Dict[str, TaskInfo]] = None) -> TaskInfo:
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
-        is_task_complete = task.complete()
+def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:
+    cache = {}
 
-    name = task.__class__.__name__
-    unique_id = task.make_unique_id()
-    is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
+    def _make_task_info_tree_with_cache(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')
+            is_task_complete = task.complete()
 
-    cache = cache or {}
-    cache_id = f'{name}_{unique_id}_{is_complete}'
-    if cache_id in cache:
-        return cache[cache_id]
+        name = task.__class__.__name__
+        unique_id = task.make_unique_id()
+        output_paths = [t.path() for t in luigi.task.flatten(task.output())]
 
-    output_paths = [t.path() for t in luigi.task.flatten(task.output())]
-    params = task.get_info(only_significant=True)
-    processing_time = task.get_processing_time()
-    if type(processing_time) == float:
-        processing_time = str(processing_time) + 's'
-    task_log = dict(task.get_task_log())
-    requires = _make_requires_info(task.requires())
+        cache_id = f'{name}_{unique_id}_{is_task_complete}'
+        if cache_id in cache:
+            return cache[cache_id]
 
-    children = luigi.task.flatten(task.requires())
-    children_task_infos: List[TaskInfo] = []
-    for child in children:
-        if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
-            children_task_infos.append(make_task_info_tree(child, ignore_task_names=ignore_task_names, cache=cache))
+        params = task.get_info(only_significant=True)
+        processing_time = task.get_processing_time()
+        if type(processing_time) == float:
+            processing_time = str(processing_time) + 's'
+        is_complete = ('COMPLETE' if is_task_complete else 'PENDING')
+        task_log = dict(task.get_task_log())
+        requires = _make_requires_info(task.requires())
 
-    task_info =  TaskInfo(name=name,
-                          unique_id=unique_id,
-                          output_paths=output_paths,
-                          params=params,
-                          processing_time=processing_time,
-                          is_complete=is_complete,
-                          task_log=task_log,
-                          requires=requires,
-                          children_task_infos=children_task_infos)
-    cache[cache_id] = task_info
-
-    return task_info
+        children = luigi.task.flatten(task.requires())
+        children_task_infos: List[TaskInfo] = []
+        for child in children:
+            if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
+                children_task_infos.append(_make_task_info_tree_with_cache(child, ignore_task_names=ignore_task_names))
+        task_info = TaskInfo(name=name,
+                             unique_id=unique_id,
+                             output_paths=output_paths,
+                             params=params,
+                             processing_time=processing_time,
+                             is_complete=is_complete,
+                             task_log=task_log,
+                             requires=requires,
+                             children_task_infos=children_task_infos)
+        cache[cache_id] = task_info
+        return task_info
+    return _make_task_info_tree_with_cache(task, ignore_task_names)
 
 
 def make_tree_info(task_info: TaskInfo, indent: str, last: bool, details: bool, abbr: bool, visited_tasks: Set[str]):

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -65,7 +65,6 @@ def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]
     unique_id = task.make_unique_id()
     output_paths = [t.path() for t in luigi.task.flatten(task.output())]
 
-
     cache = {} if cache is None else cache
     cache_id = f'{name}_{unique_id}_{is_task_complete}'
     if cache_id in cache:
@@ -85,14 +84,14 @@ def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]
         if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:
             children_task_infos.append(make_task_info_tree(child, ignore_task_names=ignore_task_names, cache=cache))
     task_info = TaskInfo(name=name,
-                            unique_id=unique_id,
-                            output_paths=output_paths,
-                            params=params,
-                            processing_time=processing_time,
-                            is_complete=is_complete,
-                            task_log=task_log,
-                            requires=requires,
-                            children_task_infos=children_task_infos)
+                         unique_id=unique_id,
+                         output_paths=output_paths,
+                         params=params,
+                         processing_time=processing_time,
+                         is_complete=is_complete,
+                         task_log=task_log,
+                         requires=requires,
+                         children_task_infos=children_task_infos)
     cache[cache_id] = task_info
     return task_info
 

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -1,4 +1,5 @@
 import typing
+from functools import lru_cache
 import warnings
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Union
@@ -56,6 +57,7 @@ def _make_requires_info(requires):
     raise TypeError(f'`requires` has unexpected type {type(requires)}. Must be `TaskOnKart`, `Iterarble[TaskOnKart]`, or `Dict[str, TaskOnKart]`')
 
 
+@lru_cache(maxsize=None)
 def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]] = None) -> TaskInfo:
     with warnings.catch_warnings():
         warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete() method')

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -6,7 +6,7 @@ import luigi.mock
 from luigi.mock import MockFileSystem, MockTarget
 
 import gokart
-from gokart.tree.task_info import dump_task_info_table, dump_task_info_tree, make_task_info_as_tree_str
+from gokart.tree.task_info import dump_task_info_table, dump_task_info_tree, make_task_info_as_tree_str, make_task_info_tree
 
 
 class _SubTask(gokart.TaskOnKart):
@@ -124,6 +124,17 @@ class TestInfo(unittest.TestCase):
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""
         self.assertRegex(tree, expected)
+
+    @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
+    def test_make_tree_info_with_cache(self):
+        task = _DoubleLoadSubTask(
+            sub1=_Task(param=1, sub=_SubTask(param=2)),
+            sub2=_Task(param=1, sub=_SubTask(param=2)),
+        )
+
+        # check child task_info is the same object
+        tree = make_task_info_tree(task)
+        self.assertTrue(tree.children_task_infos[0] is tree.children_task_infos[1])
 
 
 class _TaskInfoExampleTaskA(gokart.TaskOnKart):


### PR DESCRIPTION
I've added the `cache` argument to `make_task_info_tree` to use cache in making TaskInfo tree.

This reduces time to make TaskInfo tree especially when the task tree is large.