### PR TITLE
Suppress heavy logs on test (fix #284)

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -51,7 +51,7 @@ def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = Tr
     if reset_register:
         _reset_register()
     with LoggerConfig(level=log_level):
-        result = luigi.build([task], local_scheduler=True, detailed_summary=True, **env_params)
+        result = luigi.build([task], local_scheduler=True, detailed_summary=True, log_level=logging.getLevelName(log_level), **env_params)
         if result.status == luigi.LuigiStatusCode.FAILED:
             raise GokartBuildError(result.summary_text)
     return _get_output(task) if return_value else None

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -53,6 +53,8 @@ class _ParallelRunner(gokart.TaskOnKart):
 class RunTest(unittest.TestCase):
 
     def setUp(self):
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
         luigi.configuration.LuigiConfigParser._instance = None
         self.config_paths = copy(luigi.configuration.LuigiConfigParser._config_paths)
         luigi.mock.MockFileSystem().clear()
@@ -61,6 +63,8 @@ class RunTest(unittest.TestCase):
     def tearDown(self):
         luigi.configuration.LuigiConfigParser._config_paths = self.config_paths
         os.environ.clear()
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
 
     def test_build(self):
         text = 'test'
@@ -88,7 +92,7 @@ class RunTest(unittest.TestCase):
 
     def test_failed_task(self):
         with self.assertRaises(GokartBuildError):
-            gokart.build(_DummyFailedTask(), reset_register=False)
+            gokart.build(_DummyFailedTask(), reset_register=False, log_level=logging.CRITICAL)
 
 
 class LoggerConfigTest(unittest.TestCase):

--- a/test/test_explicit_bool_parameter.py
+++ b/test/test_explicit_bool_parameter.py
@@ -27,27 +27,27 @@ class ExplicitParsing(gokart.TaskOnKart):
         ExplicitParsing._param = self.param
 
 
-class TestExplicitBoolParameter(unittest.TestCase):
+# class TestExplicitBoolParameter(unittest.TestCase):
 
-    def test_bool_default(self):
-        self.assertTrue(WithDefaultTrue().param)
-        self.assertFalse(WithDefaultFalse().param)
+    # def test_bool_default(self):
+    #     self.assertTrue(WithDefaultTrue().param)
+    #     self.assertFalse(WithDefaultFalse().param)
 
-    def test_parse_param(self):
-        in_parse(['ExplicitParsing', '--param', 'true'], lambda task: self.assertTrue(task.param))
-        in_parse(['ExplicitParsing', '--param', 'false'], lambda task: self.assertFalse(task.param))
-        in_parse(['ExplicitParsing', '--param', 'True'], lambda task: self.assertTrue(task.param))
-        in_parse(['ExplicitParsing', '--param', 'False'], lambda task: self.assertFalse(task.param))
+    # def test_parse_param(self):
+    #     in_parse(['ExplicitParsing', '--param', 'true'], lambda task: self.assertTrue(task.param))
+    #     in_parse(['ExplicitParsing', '--param', 'false'], lambda task: self.assertFalse(task.param))
+    #     in_parse(['ExplicitParsing', '--param', 'True'], lambda task: self.assertTrue(task.param))
+    #     in_parse(['ExplicitParsing', '--param', 'False'], lambda task: self.assertFalse(task.param))
 
-    def test_missing_parameter(self):
-        with self.assertRaises(luigi.parameter.MissingParameterException):
-            in_parse(['ExplicitParsing'], lambda: True)
+    # def test_missing_parameter(self):
+    #     with self.assertRaises(luigi.parameter.MissingParameterException):
+    #         in_parse(['ExplicitParsing'], lambda: True)
 
-    def test_value_error(self):
-        with self.assertRaises(ValueError):
-            in_parse(['ExplicitParsing', '--param', 'Foo'], lambda: True)
+    # def test_value_error(self):
+    #     with self.assertRaises(ValueError):
+    #         in_parse(['ExplicitParsing', '--param', 'Foo'], lambda: True)
 
-    def test_expected_one_argment_error(self):
-        # argparse throw "expected one argument" error
-        with self.assertRaises(SystemExit):
-            in_parse(['ExplicitParsing', '--param'], lambda: True)
+    # def test_expected_one_argment_error(self):
+    #     # argparse throw "expected one argument" error
+    #     with self.assertRaises(SystemExit):
+    #         in_parse(['ExplicitParsing', '--param'], lambda: True)

--- a/test/test_explicit_bool_parameter.py
+++ b/test/test_explicit_bool_parameter.py
@@ -27,27 +27,27 @@ class ExplicitParsing(gokart.TaskOnKart):
         ExplicitParsing._param = self.param
 
 
-# class TestExplicitBoolParameter(unittest.TestCase):
+class TestExplicitBoolParameter(unittest.TestCase):
 
-    # def test_bool_default(self):
-    #     self.assertTrue(WithDefaultTrue().param)
-    #     self.assertFalse(WithDefaultFalse().param)
+    def test_bool_default(self):
+        self.assertTrue(WithDefaultTrue().param)
+        self.assertFalse(WithDefaultFalse().param)
 
-    # def test_parse_param(self):
-    #     in_parse(['ExplicitParsing', '--param', 'true'], lambda task: self.assertTrue(task.param))
-    #     in_parse(['ExplicitParsing', '--param', 'false'], lambda task: self.assertFalse(task.param))
-    #     in_parse(['ExplicitParsing', '--param', 'True'], lambda task: self.assertTrue(task.param))
-    #     in_parse(['ExplicitParsing', '--param', 'False'], lambda task: self.assertFalse(task.param))
+    def test_parse_param(self):
+        in_parse(['ExplicitParsing', '--param', 'true'], lambda task: self.assertTrue(task.param))
+        in_parse(['ExplicitParsing', '--param', 'false'], lambda task: self.assertFalse(task.param))
+        in_parse(['ExplicitParsing', '--param', 'True'], lambda task: self.assertTrue(task.param))
+        in_parse(['ExplicitParsing', '--param', 'False'], lambda task: self.assertFalse(task.param))
 
-    # def test_missing_parameter(self):
-    #     with self.assertRaises(luigi.parameter.MissingParameterException):
-    #         in_parse(['ExplicitParsing'], lambda: True)
+    def test_missing_parameter(self):
+        with self.assertRaises(luigi.parameter.MissingParameterException):
+            in_parse(['ExplicitParsing'], lambda: True)
 
-    # def test_value_error(self):
-    #     with self.assertRaises(ValueError):
-    #         in_parse(['ExplicitParsing', '--param', 'Foo'], lambda: True)
+    def test_value_error(self):
+        with self.assertRaises(ValueError):
+            in_parse(['ExplicitParsing', '--param', 'Foo'], lambda: True)
 
-    # def test_expected_one_argment_error(self):
-    #     # argparse throw "expected one argument" error
-    #     with self.assertRaises(SystemExit):
-    #         in_parse(['ExplicitParsing', '--param'], lambda: True)
+    def test_expected_one_argment_error(self):
+        # argparse throw "expected one argument" error
+        with self.assertRaises(SystemExit):
+            in_parse(['ExplicitParsing', '--param'], lambda: True)

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -31,7 +31,7 @@ class TestInfo(unittest.TestCase):
         task = _Task(param=1, sub=_SubTask(param=2))
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = gokart.info.make_tree_info(task)
         expected = r"""
 └─-\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -46,7 +46,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = gokart.info.make_tree_info(task)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -64,7 +64,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = gokart.info.make_tree_info(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -82,7 +82,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = gokart.info.make_tree_info(task, abbr=False, ignore_task_names=['_Task'])
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -14,6 +14,12 @@ class TestInfo(unittest.TestCase):
 
     def setUp(self) -> None:
         MockFileSystem().clear()
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
+
+    def tearDown(self) -> None:
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
 
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
     def test_make_tree_info_pending(self):

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -31,7 +31,7 @@ class TestInfo(unittest.TestCase):
         task = _Task(param=1, sub=_SubTask(param=2))
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = gokart.info.make_tree_info(task)
         expected = r"""
 └─-\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -46,7 +46,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = gokart.info.make_tree_info(task)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -64,7 +64,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = gokart.info.make_tree_info(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -82,7 +82,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = gokart.info.make_tree_info(task, abbr=False, ignore_task_names=['_Task'])
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""

--- a/test/test_pandas_type_check_framework.py
+++ b/test/test_pandas_type_check_framework.py
@@ -2,6 +2,7 @@ import unittest
 from logging import getLogger
 from typing import Any, Dict
 from unittest.mock import patch
+import luigi
 
 import pandas as pd
 from luigi.mock import MockFileSystem, MockTarget
@@ -59,7 +60,13 @@ class _DummySuccessTask(gokart.TaskOnKart):
 class TestPandasTypeCheckFramework(unittest.TestCase):
 
     def setUp(self) -> None:
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
         MockFileSystem().clear()
+
+    def tearDown(self) -> None:
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
 
     @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummyFailTask', '--log-level=CRITICAL', '--local-scheduler', '--no-lock'])
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))

--- a/test/test_pandas_type_check_framework.py
+++ b/test/test_pandas_type_check_framework.py
@@ -2,8 +2,8 @@ import unittest
 from logging import getLogger
 from typing import Any, Dict
 from unittest.mock import patch
-import luigi
 
+import luigi
 import pandas as pd
 from luigi.mock import MockFileSystem, MockTarget
 

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -83,7 +83,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = make_task_info_as_tree_str(task)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -101,7 +101,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = make_task_info_as_tree_str(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -119,7 +119,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
         tree = make_task_info_as_tree_str(task, abbr=False, ignore_task_names=['_Task'])
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -68,7 +68,7 @@ class TestInfo(unittest.TestCase):
         task = _Task(param=1, sub=_SubTask(param=2))
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True)
+        gokart.build(task, reset_register=False)
         tree = make_task_info_as_tree_str(task)
         expected = r"""
 └─-\(COMPLETE\) _Task\[[a-z0-9]*\]
@@ -83,7 +83,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = make_task_info_as_tree_str(task)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -101,7 +101,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = make_task_info_as_tree_str(task, abbr=False)
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]
@@ -119,7 +119,7 @@ class TestInfo(unittest.TestCase):
         )
 
         # check after sub task runs
-        luigi.build([task], local_scheduler=True, log_level='CRITICAL')
+        gokart.build(task, reset_register=False)
         tree = make_task_info_as_tree_str(task, abbr=False, ignore_task_names=['_Task'])
         expected = r"""
 └─-\(COMPLETE\) _DoubleLoadSubTask\[[a-z0-9]*\]$"""

--- a/test/tree/test_task_info.py
+++ b/test/tree/test_task_info.py
@@ -51,6 +51,12 @@ class TestInfo(unittest.TestCase):
 
     def setUp(self) -> None:
         MockFileSystem().clear()
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
+
+    def tearDown(self) -> None:
+        luigi.setup_logging.DaemonLogging._configured = False
+        luigi.setup_logging.InterfaceLogging._configured = False
 
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
     def test_make_tree_info_pending(self):


### PR DESCRIPTION
Fixes #284

# FIXES

* 1. reconfigure `luigi.setup_logging` configs on each setUp and tearDown
* 2. gokart.build() propagate log_level also to `luigi` namespace

# PROBLEMS: heavy logs

https://github.com/m3dev/gokart/runs/6319432334?check_suite_focus=true

<img width="841" alt="image" src="https://user-images.githubusercontent.com/1065318/167279171-891c7770-1c3c-456f-98aa-d718c36657c2.png">

# Reason1: cache of logging cofiguration

* luigi.BaseLogging has cache for disabling re-configuration
  * https://github.com/spotify/luigi/blob/4d0576c7c265afcb228097af79f316ba0de0242c/luigi/setup_logging.py#L57
* So, '--log-level=CRITICAL' of each test does noting
  * https://github.com/m3dev/gokart/blob/210e282303b4ca3013bd0acd781f6030547a773a/test/test_pandas_type_check_framework.py#L64

# Reason2:  gokart.build(log_level=...) only set log_level of `gokart` namespace

Info level logs from `luigi` namespace had been shown.
