### PR TITLE
Fix `TaskOnKart.fix_random_seed_value` cannnot handle None

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -53,8 +53,9 @@ class TaskOnKart(luigi.Task):
                                       significant=False)
     fix_random_seed_methods = luigi.ListParameter(default=['random.seed', 'numpy.random.seed'], description='Fix random seed method list.', significant=False)
     FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER = -42497368
-    fix_random_seed_value = luigi.IntParameter(default=FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER, description='Fix random seed method value.',
-                                               significant=False)  # should fix with OptionalIntParameter after newer luigi will be released
+    fix_random_seed_value = luigi.IntParameter(
+        default=FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER, description='Fix random seed method value.',
+        significant=False)  # FIXME: should fix with OptionalIntParameter after newer luigi (https://github.com/spotify/luigi/pull/3079) will be released
 
     redis_host = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
     redis_port = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -52,7 +52,8 @@ class TaskOnKart(luigi.Task):
                                       description='If this is false, this task is not treated as a part of dependent tasks for the unique id.',
                                       significant=False)
     fix_random_seed_methods = luigi.ListParameter(default=['random.seed', 'numpy.random.seed'], description='Fix random seed method list.', significant=False)
-    fix_random_seed_value = luigi.IntParameter(default=None, description='Fix random seed method value.', significant=False)
+    FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER = -42497368
+    fix_random_seed_value = luigi.IntParameter(default=FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER, description='Fix random seed method value.', significant=False) # should fix with OptionalIntParameter after newer luigi will be released
 
     redis_host = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
     redis_port = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
@@ -389,7 +390,7 @@ class TaskOnKart(luigi.Task):
         return success_methods
 
     def _get_random_seed(self):
-        if self.fix_random_seed_value:
+        if self.fix_random_seed_value and (not self.fix_random_seed_value == self.FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER):
             return self.fix_random_seed_value
         return int(self.make_unique_id(), 16) % (2**32 - 1)  # maximum numpy.random.seed
 

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -53,7 +53,8 @@ class TaskOnKart(luigi.Task):
                                       significant=False)
     fix_random_seed_methods = luigi.ListParameter(default=['random.seed', 'numpy.random.seed'], description='Fix random seed method list.', significant=False)
     FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER = -42497368
-    fix_random_seed_value = luigi.IntParameter(default=FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER, description='Fix random seed method value.', significant=False) # should fix with OptionalIntParameter after newer luigi will be released
+    fix_random_seed_value = luigi.IntParameter(default=FIX_RANDOM_SEED_VALUE_NONE_MAGIC_NUMBER, description='Fix random seed method value.',
+                                               significant=False)  # should fix with OptionalIntParameter after newer luigi will be released
 
     redis_host = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)
     redis_port = luigi.OptionalParameter(default=None, description='Task lock check is deactivated, when None.', significant=False)

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -536,6 +536,12 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(False, gokart.TaskOnKart.is_task_on_kart(list()))
         self.assertEqual(True, gokart.TaskOnKart.is_task_on_kart((gokart.TaskOnKart(), gokart.TaskOnKart())))
 
+    def test_serialize_and_deserialize_default_values(self):
+        task = gokart.TaskOnKart()
+        deserialized: gokart.TaskOnKart = luigi.task_register.load_task(None, task.get_task_family(), task.to_str_params())
+        self.assertDictEqual(task.to_str_params(), deserialized.to_str_params())
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -542,6 +542,5 @@ class TaskTest(unittest.TestCase):
         self.assertDictEqual(task.to_str_params(), deserialized.to_str_params())
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
resolve https://github.com/m3dev/gokart/issues/286

# Problem

Cannot set None for luigi.IntParameter. But `TaskOnKart.fix_random_seed_value` does this.

So following code fails

```python
        task = gokart.TaskOnKart()
        luigi.task_register.load_task(None, task.get_task_family(), task.to_str_params())
```

# Solution

* Add above test
* Introduce magic number instead of None