### PR TITLE
Delete warning

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -267,7 +267,7 @@ class TaskOnKart(luigi.Task):
             return pd.DataFrame(columns=required_columns)
         assert required_columns.issubset(set(data.columns)), f'data must have columns {required_columns}, but actually have only {data.columns}.'
         if drop_columns:
-            data = data[required_columns]
+            data = data[list(required_columns)]
         return data
 
     def dump(self, obj, target: Union[None, str, TargetOnKart] = None) -> None:


### PR DESCRIPTION
I got the following warning message, and I fixed it.

```
/usr/local/lib/python3.9/site-packages/gokart/task.py:267: FutureWarning: Passing a set as an indexer is deprecated and will raise in a future version. Use a list instead.
data = data[required_columns]
```