### PR TITLE
fix: annotation of inherits_config_params

### DIFF
--- a/gokart/config_params.py
+++ b/gokart/config_params.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Type
 
 import luigi
 
@@ -19,10 +19,10 @@ class inherits_config_params:
         self._config_class: luigi.Config = config_class
         self._parameter_alias: Dict[str, str] = parameter_alias if parameter_alias is not None else {}
 
-    def __call__(self, task: gokart.TaskOnKart):
+    def __call__(self, task_class: Type[gokart.TaskOnKart]):
         # wrap task to prevent task name from being changed
-        @luigi.task._task_wraps(task)
-        class Wrapped(task):
+        @luigi.task._task_wraps(task_class)
+        class Wrapped(task_class):
 
             @classmethod
             def get_param_values(cls, params, args, kwargs):


### PR DESCRIPTION
`inherits_config_params` is not called with `TaskOnKart` **instance** but `TaskOnKart` **class itself** or its subclass.
This suppresses mypy error.
And `task_class` is better for the parameter name than `task`.
I think this change does not have a significant impact on usage because `inherits_config_params` is used as decorator.