### PR TITLE
Added should_dump_supplementary_log_files option

### DIFF
--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -244,3 +244,9 @@ TaskOnKart.fail_on_empty_dump
 Please refer to :doc:`for_pandas`.
 
 
+TaskOnKart.should_dump_supplementary_log_files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to dump supplementary files (task_log, random_seed, task_params, processing_time, module_versions) or not. Default is True.
+
+Note that when set to False, task_info functions (e.g. gokart.tree.task_info.make_task_info_as_tree_str()) cannot be used.


### PR DESCRIPTION
[What]
TaskOnKart.should_dump_supplementary_log_files is an option to control whether to dump supplementary files (task_log, random_seed, task_params, processing_time, module_versions) or not. Default is True, which means to dump as before.

[Why]
When each task runs, they will make 1 or more output files as defined in task.run(). Besides, 5 supplementary files (task_log, random_seed, task_params, processing_time, module_versions) will also be dumped. 
When using cloud data storage and running a large number of tasks, number of files will affect the price for data processing. This option will skip the dumping process of supplementary files to keep the price low.

Please review.