### PR TITLE
Hide private params from logs

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import luigi
 import pandas as pd
+from luigi.parameter import ParameterVisibility
 
 import gokart
 from gokart.file_processor import FileProcessor
@@ -455,6 +456,19 @@ class TaskOnKart(luigi.Task):
         """
         Build a task representation like `MyTask(param1=1.5, param2='5', data_task=DataTask(id=35tyi))`
         """
+        return self._get_task_string()
+
+    def __str__(self):
+        """
+        Build a human-readable task representation like `MyTask(param1=1.5, param2='5', data_task=DataTask(id=35tyi))`
+        This includes only public parameters
+        """
+        return self._get_task_string(only_public=True)
+
+    def _get_task_string(self, only_public=False):
+        """
+        Convert a task representation like `MyTask(param1=1.5, param2='5', data_task=DataTask(id=35tyi))`
+        """
         params = self.get_params()
         param_values = self.get_param_values(params, [], self.param_kwargs)
 
@@ -463,7 +477,7 @@ class TaskOnKart(luigi.Task):
         param_objs = dict(params)
         for param_name, param_value in param_values:
             param_obj = param_objs[param_name]
-            if param_obj.significant:
+            if param_obj.significant and ((not only_public) or param_obj.visibility == ParameterVisibility.PUBLIC):
                 repr_parts.append(f'{param_name}={self._make_representation(param_obj, param_value)}')
 
         task_str = f'{self.get_task_family()}({", ".join(repr_parts)})'

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -85,6 +85,18 @@ class _DummyTaskWithoutLock(gokart.TaskOnKart):
         pass
 
 
+class _DummySubTaskWithPrivateParameter(gokart.TaskOnKart):
+    task_namespace = __name__
+
+
+class _DummyTaskWithPrivateParameter(gokart.TaskOnKart):
+    task_namespace = __name__
+    int_param = luigi.IntParameter()
+    private_int_param = luigi.IntParameter(visibility=ParameterVisibility.PRIVATE)
+    task_param = TaskInstanceParameter()
+    list_task_param = ListTaskInstanceParameter()
+
+
 class TaskTest(unittest.TestCase):
 
     def setUp(self):
@@ -482,39 +494,25 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(with_task.requires()['a_task'], without_task)
 
     def test_repr(self):
-
-        class _SubTask(gokart.TaskOnKart):
-            task_namespace = __name__
-
-        class _Task(gokart.TaskOnKart):
-            task_namespace = __name__
-            int_param = luigi.IntParameter()
-            private_int_param = luigi.IntParameter(visibility=ParameterVisibility.PRIVATE)
-            task_param = TaskInstanceParameter()
-            list_task_param = ListTaskInstanceParameter()
-
-        task = _Task(int_param=1, private_int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
-        sub_task_id = _SubTask().make_unique_id()
-        expected = f'{__name__}._Task(int_param=1, private_int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
-            f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'
+        task = _DummyTaskWithPrivateParameter(int_param=1,
+                                              private_int_param=1,
+                                              task_param=_DummySubTaskWithPrivateParameter(),
+                                              list_task_param=[_DummySubTaskWithPrivateParameter(),
+                                                               _DummySubTaskWithPrivateParameter()])
+        sub_task_id = _DummySubTaskWithPrivateParameter().make_unique_id()
+        expected = f'{__name__}._DummyTaskWithPrivateParameter(int_param=1, private_int_param=1, task_param={__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), ' \
+            f'list_task_param=[{__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), {__name__}._DummySubTaskWithPrivateParameter({sub_task_id})])'
         self.assertEqual(expected, repr(task))
 
     def test_str(self):
-
-        class _SubTask(gokart.TaskOnKart):
-            task_namespace = __name__
-
-        class _Task(gokart.TaskOnKart):
-            task_namespace = __name__
-            int_param = luigi.IntParameter()
-            private_int_param = luigi.IntParameter(visibility=ParameterVisibility.PRIVATE)
-            task_param = TaskInstanceParameter()
-            list_task_param = ListTaskInstanceParameter()
-
-        task = _Task(int_param=1, private_int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
-        sub_task_id = _SubTask().make_unique_id()
-        expected = f'{__name__}._Task(int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
-            f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'
+        task = _DummyTaskWithPrivateParameter(int_param=1,
+                                              private_int_param=1,
+                                              task_param=_DummySubTaskWithPrivateParameter(),
+                                              list_task_param=[_DummySubTaskWithPrivateParameter(),
+                                                               _DummySubTaskWithPrivateParameter()])
+        sub_task_id = _DummySubTaskWithPrivateParameter().make_unique_id()
+        expected = f'{__name__}._DummyTaskWithPrivateParameter(int_param=1, task_param={__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), ' \
+            f'list_task_param=[{__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), {__name__}._DummySubTaskWithPrivateParameter({sub_task_id})])'
         self.assertEqual(expected, str(task))
 
     def test_run_with_lock_decorator(self):

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import luigi
 import pandas as pd
+from luigi.parameter import ParameterVisibility
 from luigi.util import inherits
 
 import gokart
@@ -488,10 +489,29 @@ class TaskTest(unittest.TestCase):
         class _Task(gokart.TaskOnKart):
             task_namespace = __name__
             int_param = luigi.IntParameter()
+            private_int_param = luigi.IntParameter(visibility=ParameterVisibility.PRIVATE)
             task_param = TaskInstanceParameter()
             list_task_param = ListTaskInstanceParameter()
 
-        task = _Task(int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
+        task = _Task(int_param=1, private_int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
+        sub_task_id = _SubTask().make_unique_id()
+        expected = f'{__name__}._Task(int_param=1, private_int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
+            f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'
+        self.assertEqual(expected, repr(task))
+
+    def test_str(self):
+
+        class _SubTask(gokart.TaskOnKart):
+            task_namespace = __name__
+
+        class _Task(gokart.TaskOnKart):
+            task_namespace = __name__
+            int_param = luigi.IntParameter()
+            private_int_param = luigi.IntParameter(visibility=ParameterVisibility.PRIVATE)
+            task_param = TaskInstanceParameter()
+            list_task_param = ListTaskInstanceParameter()
+
+        task = _Task(int_param=1, private_int_param=1, task_param=_SubTask(), list_task_param=[_SubTask(), _SubTask()])
         sub_task_id = _SubTask().make_unique_id()
         expected = f'{__name__}._Task(int_param=1, task_param={__name__}._SubTask({sub_task_id}), ' \
             f'list_task_param=[{__name__}._SubTask({sub_task_id}), {__name__}._SubTask({sub_task_id})])'


### PR DESCRIPTION
I've implemented `__str__` for task representations with only public parameters.

## Problems
When running the task with [private parameters](https://luigi.readthedocs.io/en/stable/parameters.html#parameter-visibility), the worker now emits the logs including the raw values of private parameters.

This is caused by the implementation of `__repr__` that builds the task representation with all the significant parameters, and `str(task)` calls it because `__str__` is not implemented. It is reasonable that `__repr__` Includes all the siginificant parameters since `__repr__` should identify the task,  but I think `str(task)` should not include private parameters.

## Solution
I've implemented `_get_task_string(only_public=False)` and `__str__`, and added unittest for them.