### PR TITLE
Fix typo: logginge -> logging

### DIFF
--- a/docs/intro_to_gokart.rst
+++ b/docs/intro_to_gokart.rst
@@ -153,7 +153,7 @@ To output logs of each tasks, you can pass `~log_level` parameter to `~gokart.bu
 
 .. code:: python
 
-    gokart.build(SampleTask(param='hello'), return_value=False, log_level=logginge.DEBUG)
+    gokart.build(SampleTask(param='hello'), return_value=False, log_level=logging.DEBUG)
 
 
 This feature is very useful for running `~gokart` on jupyter notebook.


### PR DESCRIPTION
It may seem trivial, but I found a typo in docs (intro_to_gokart.html#gokart-build) and fixed it.


![intro_to_gokart html](https://user-images.githubusercontent.com/44169535/218048842-3841d2ef-d07d-4968-826e-2604a78cf129.png)
