### PR TITLE
Fix CI settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox-gh-actions poetry
+        python -m pip install poetry
+        poetry run python -m pip install tox-gh-actions
         poetry install
     - name: Test with tox
       run: poetry run tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,yapf,isort,flake8}
+envlist = py{38,39,310,311},yapf,isort,flake8
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
This PR relate with https://github.com/m3dev/kannon/pull/13. Special thanks @yokomotod.

Currently, the tox-gh-actions plugin is not recognized and all tox environments are running.

### previous log: [py3.8](https://github.com/m3dev/gokart/actions/runs/4149531993/jobs/7178545695)

expect:

```
OK
  py38: OK (35.82=setup[1.13]+cmd[34.70] seconds)
```

actual: 

```
OK
  py38: OK (35.82=setup[1.13]+cmd[34.70] seconds)
  py39: SKIP (0.83 seconds)
  py310: OK (34.86=setup[1.20]+cmd[33.67] seconds)
  py311: SKIP (0.01 seconds)
  pyyapf: OK (34.55=setup[0.98]+cmd[33.57] seconds)
  pyisort: OK (34.59=setup[0.99]+cmd[33.60] seconds)
  pyflake8: OK (34.55=setup[1.00]+cmd[33.55] seconds)
  congratulations :) (175.39 seconds)
```