### PR TITLE
Set encoding when saving csv

### DIFF
--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -255,7 +255,7 @@ Note that when set to False, task_info functions (e.g. gokart.tree.task_info.mak
 Dump csv with encoding
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can dump csv file by impementing `Task.output()` method as follows: 
+You can dump csv file by implementing `Task.output()` method as follows: 
 
 .. code:: python
 

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -264,7 +264,7 @@ You can dump csv file by implementing `Task.output()` method as follows:
 
 By default, csv file is dumped with `utf-8` encoding.
 
-If you want to dump csv file with other encoding, you can use `encoding` parameter as follows:
+If you want to dump csv file with other encodings, you can use `encoding` parameter as follows:
 
 .. code:: python
 

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -250,3 +250,25 @@ TaskOnKart.should_dump_supplementary_log_files
 Whether to dump supplementary files (task_log, random_seed, task_params, processing_time, module_versions) or not. Default is True.
 
 Note that when set to False, task_info functions (e.g. gokart.tree.task_info.make_task_info_as_tree_str()) cannot be used.
+
+
+Dump csv with encoding
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can dump csv file by impementing `Task.output()` method as follows: 
+
+.. code:: python
+
+    def output(self):
+        return self.make_target('file_name.csv')
+
+By default, csv file is dumped with `utf-8` encoding.
+
+If you want to dump csv file with other encoding, you can use `encoding` parameter as follows:
+
+.. code:: python
+
+    def output(self):
+        return self.make_target('file_name.csv', encoding='cp932')
+        # This will dump csv as 'cp932' which is used in Windows.
+        

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -7,10 +7,10 @@ from logging import getLogger
 import luigi
 import luigi.contrib.s3
 import luigi.format
-from luigi.format import TextFormat
 import numpy as np
 import pandas as pd
 import pandas.errors
+from luigi.format import TextFormat
 
 from gokart.object_storage import ObjectStorage
 

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -7,6 +7,7 @@ from logging import getLogger
 import luigi
 import luigi.contrib.s3
 import luigi.format
+from luigi.format import TextFormat
 import numpy as np
 import pandas as pd
 import pandas.errors
@@ -120,23 +121,24 @@ class TextFileProcessor(FileProcessor):
 
 class CsvFileProcessor(FileProcessor):
 
-    def __init__(self, sep=','):
+    def __init__(self, sep=',', encoding: str = 'utf-8'):
         self._sep = sep
+        self._encoding = encoding
         super(CsvFileProcessor, self).__init__()
 
     def format(self):
-        return None
+        return TextFormat(encoding=self._encoding)
 
     def load(self, file):
         try:
-            return pd.read_csv(file, sep=self._sep)
+            return pd.read_csv(file, sep=self._sep, encoding=self._encoding)
         except pd.errors.EmptyDataError:
             return pd.DataFrame()
 
     def dump(self, obj, file):
         assert isinstance(obj, (pd.DataFrame, pd.Series)), \
             f'requires pd.DataFrame or pd.Series, but {type(obj)} is passed.'
-        obj.to_csv(file, mode='wt', index=False, sep=self._sep, header=True)
+        obj.to_csv(file, mode='wt', index=False, sep=self._sep, header=True, encoding=self._encoding)
 
 
 class GzipFileProcessor(FileProcessor):

--- a/test/test_file_processor.py
+++ b/test/test_file_processor.py
@@ -1,8 +1,8 @@
 import tempfile
 import unittest
-from luigi import LocalTarget
 
 import pandas as pd
+from luigi import LocalTarget
 
 from gokart.file_processor import CsvFileProcessor
 

--- a/test/test_file_processor.py
+++ b/test/test_file_processor.py
@@ -1,0 +1,69 @@
+import tempfile
+import unittest
+from luigi import LocalTarget
+
+import pandas as pd
+
+from gokart.file_processor import CsvFileProcessor
+
+
+class TestCsvFileProcessor(unittest.TestCase):
+
+    def test_dump_csv_with_utf8(self):
+
+        df = pd.DataFrame({'あ': [1, 2, 3], 'い': [4, 5, 6]})
+        processor = CsvFileProcessor()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = f'{temp_dir}/temp.csv'
+
+            local_target = LocalTarget(path=temp_path, format=processor.format())
+            with local_target.open('w') as f:
+                processor.dump(df, f)
+
+            # read with utf-8 to check if the file is dumped with utf8
+            loaded_df = pd.read_csv(temp_path, encoding='utf-8')
+            pd.testing.assert_frame_equal(df, loaded_df)
+
+    def test_dump_csv_with_cp932(self):
+        df = pd.DataFrame({'あ': [1, 2, 3], 'い': [4, 5, 6]})
+        processor = CsvFileProcessor(encoding='cp932')
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = f'{temp_dir}/temp.csv'
+
+            local_target = LocalTarget(path=temp_path, format=processor.format())
+            with local_target.open('w') as f:
+                processor.dump(df, f)
+
+            # read with cp932 to check if the file is dumped with cp932
+            loaded_df = pd.read_csv(temp_path, encoding='cp932')
+            pd.testing.assert_frame_equal(df, loaded_df)
+
+    def test_load_csv_with_utf8(self):
+        df = pd.DataFrame({'あ': [1, 2, 3], 'い': [4, 5, 6]})
+        processor = CsvFileProcessor()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = f'{temp_dir}/temp.csv'
+            df.to_csv(temp_path, encoding='utf-8', index=False)
+
+            local_target = LocalTarget(path=temp_path, format=processor.format())
+            with local_target.open('r') as f:
+                # read with utf-8 to check if the file is dumped with utf8
+                loaded_df = processor.load(f)
+                pd.testing.assert_frame_equal(df, loaded_df)
+
+    def test_load_csv_with_cp932(self):
+        df = pd.DataFrame({'あ': [1, 2, 3], 'い': [4, 5, 6]})
+        processor = CsvFileProcessor(encoding='cp932')
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = f'{temp_dir}/temp.csv'
+            df.to_csv(temp_path, encoding='cp932', index=False)
+
+            local_target = LocalTarget(path=temp_path, format=processor.format())
+            with local_target.open('r') as f:
+                # read with cp932 to check if the file is dumped with cp932
+                loaded_df = processor.load(f)
+                pd.testing.assert_frame_equal(df, loaded_df)


### PR DESCRIPTION
I've added CsvFileProcessor._encoding to allow specifying encodings when dumping in csv.