### PR TITLE
[docs] fix csv encoding option

### DIFF
--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -270,7 +270,7 @@ If you want to dump csv file with other encodings, you can use `encoding` parame
 
     from gokart.file_processor import CsvFileProcessor
 
-        def output(self):
-            return self.make_target('file_name.csv', processor=CsvFileProcessor(encoding='cp932'))
-            # This will dump csv as 'cp932' which is used in Windows.
+    def output(self):
+        return self.make_target('file_name.csv', processor=CsvFileProcessor(encoding='cp932'))
+        # This will dump csv as 'cp932' which is used in Windows.
             

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -268,7 +268,9 @@ If you want to dump csv file with other encodings, you can use `encoding` parame
 
 .. code:: python
 
-    def output(self):
-        return self.make_target('file_name.csv', encoding='cp932')
-        # This will dump csv as 'cp932' which is used in Windows.
-        
+    from gokart.file_processor import CsvFileProcessor
+
+        def output(self):
+            return self.make_target('file_name.csv', processor=CsvFileProcessor(encoding='cp932'))
+            # This will dump csv as 'cp932' which is used in Windows.
+            

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -273,4 +273,3 @@ If you want to dump csv file with other encodings, you can use `encoding` parame
     def output(self):
         return self.make_target('file_name.csv', processor=CsvFileProcessor(encoding='cp932'))
         # This will dump csv as 'cp932' which is used in Windows.
-            


### PR DESCRIPTION
https://github.com/m3dev/gokart/pull/317 added the `encoding` option into `CsvFileProcessor`, but the following code in the [docs](https://github.com/m3dev/gokart/blob/master/docs/task_on_kart.rst#dump-csv-with-encoding) doesn't work.

```python
def output(self):
    return self.make_target('file_name.csv', encoding='cp932')
```

In fact, we have to directly pass `CsvFileProcessor` with `encoding='cp932'` to `TaskOnKart.make_target`.