### PR TITLE
Add ini file processor

### DIFF
--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -90,6 +90,7 @@ It is also possible to specify a file format other than pkl. The supported file 
 - .feather
 - .png
 - .jpg
+- .ini
 
 
 If dump something other than the above, can use :func:`~gokart.TaskOnKart.make_model_target`.

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -10,8 +10,8 @@ import luigi.format
 import numpy as np
 import pandas as pd
 import pandas.errors
-from luigi.format import TextFormat
 from luigi.configuration.cfg_parser import LuigiConfigParser
+from luigi.format import TextFormat
 
 from gokart.object_storage import ObjectStorage
 
@@ -298,6 +298,8 @@ def make_file_processor(file_path: str, store_index_in_feather: bool) -> FilePro
         '.png': BinaryFileProcessor(),
         '.jpg': BinaryFileProcessor(),
         '.ini': ConfigFileProcessor(),
+        '.cfg': ConfigFileProcessor(),
+        '.conf': ConfigFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -10,7 +10,6 @@ import luigi.format
 import numpy as np
 import pandas as pd
 import pandas.errors
-from luigi.configuration.cfg_parser import LuigiConfigParser
 from luigi.format import TextFormat
 
 from gokart.object_storage import ObjectStorage

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -269,6 +269,7 @@ class FeatherFileProcessor(FileProcessor):
 def make_file_processor(file_path: str, store_index_in_feather: bool) -> FileProcessor:
     extension2processor = {
         '.txt': TextFileProcessor(),
+        '.ini': TextFileProcessor(),
         '.csv': CsvFileProcessor(sep=','),
         '.tsv': CsvFileProcessor(sep='\t'),
         '.pkl': PickleFileProcessor(),
@@ -280,7 +281,6 @@ def make_file_processor(file_path: str, store_index_in_feather: bool) -> FilePro
         '.feather': FeatherFileProcessor(store_index_in_feather=store_index_in_feather),
         '.png': BinaryFileProcessor(),
         '.jpg': BinaryFileProcessor(),
-        '.ini': TextFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -1,3 +1,4 @@
+import configparser
 import os
 import pickle
 import xml.etree.ElementTree as ET
@@ -266,6 +267,21 @@ class FeatherFileProcessor(FileProcessor):
         dump_obj.to_feather(file.name)
 
 
+class IniFileProcessor(FileProcessor):
+
+    def format(self):
+        return None
+
+    def load(self, file):
+        config = configparser.ConfigParser()
+        config.read_file(file)
+        return config
+
+    def dump(self, obj, file):
+        assert isinstance(obj, configparser.ConfigParser)
+        obj.write(file)
+
+
 def make_file_processor(file_path: str, store_index_in_feather: bool) -> FileProcessor:
     extension2processor = {
         '.txt': TextFileProcessor(),
@@ -280,6 +296,7 @@ def make_file_processor(file_path: str, store_index_in_feather: bool) -> FilePro
         '.feather': FeatherFileProcessor(store_index_in_feather=store_index_in_feather),
         '.png': BinaryFileProcessor(),
         '.jpg': BinaryFileProcessor(),
+        '.ini': IniFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -267,22 +267,6 @@ class FeatherFileProcessor(FileProcessor):
         dump_obj.to_feather(file.name)
 
 
-class ConfigFileProcessor(FileProcessor):
-
-    def format(self):
-        return None
-
-    def load(self, file):
-        config = LuigiConfigParser()
-        config.read_file(file)
-        return config
-
-    def dump(self, obj, file):
-        assert isinstance(obj, LuigiConfigParser), \
-            f'requires LuigiConfigParser, but {type(obj)} is passed.'
-        obj.write(file)
-
-
 def make_file_processor(file_path: str, store_index_in_feather: bool) -> FileProcessor:
     extension2processor = {
         '.txt': TextFileProcessor(),
@@ -297,9 +281,7 @@ def make_file_processor(file_path: str, store_index_in_feather: bool) -> FilePro
         '.feather': FeatherFileProcessor(store_index_in_feather=store_index_in_feather),
         '.png': BinaryFileProcessor(),
         '.jpg': BinaryFileProcessor(),
-        '.ini': ConfigFileProcessor(),
-        '.cfg': ConfigFileProcessor(),
-        '.conf': ConfigFileProcessor(),
+        '.ini': TextFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -1,4 +1,3 @@
-import configparser
 import os
 import pickle
 import xml.etree.ElementTree as ET
@@ -12,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pandas.errors
 from luigi.format import TextFormat
+from luigi.configuration.cfg_parser import LuigiConfigParser
 
 from gokart.object_storage import ObjectStorage
 
@@ -267,19 +267,19 @@ class FeatherFileProcessor(FileProcessor):
         dump_obj.to_feather(file.name)
 
 
-class IniFileProcessor(FileProcessor):
+class ConfigFileProcessor(FileProcessor):
 
     def format(self):
         return None
 
     def load(self, file):
-        config = configparser.ConfigParser()
+        config = LuigiConfigParser()
         config.read_file(file)
         return config
 
     def dump(self, obj, file):
-        assert isinstance(obj, configparser.ConfigParser), \
-            f'requires configparser.ConfigParser, but {type(obj)} is passed.'
+        assert isinstance(obj, LuigiConfigParser), \
+            f'requires LuigiConfigParser, but {type(obj)} is passed.'
         obj.write(file)
 
 
@@ -297,7 +297,7 @@ def make_file_processor(file_path: str, store_index_in_feather: bool) -> FilePro
         '.feather': FeatherFileProcessor(store_index_in_feather=store_index_in_feather),
         '.png': BinaryFileProcessor(),
         '.jpg': BinaryFileProcessor(),
-        '.ini': IniFileProcessor(),
+        '.ini': ConfigFileProcessor(),
     }
 
     extension = os.path.splitext(file_path)[1]

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -278,7 +278,8 @@ class IniFileProcessor(FileProcessor):
         return config
 
     def dump(self, obj, file):
-        assert isinstance(obj, configparser.ConfigParser)
+        assert isinstance(obj, configparser.ConfigParser), \
+            f'requires configparser.ConfigParser, but {type(obj)} is passed.'
         obj.write(file)
 
 

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -123,7 +123,7 @@ class LocalTargetTest(unittest.TestCase):
         obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': 2}
         obj['example'] = {}
         obj['example']['d'] = 'foo'
-        obj['example']['e'] = True
+        obj['example']['e'] = 'true'
         file_path = os.path.join(_get_temporary_directory(), 'test.ini')
 
         target = make_target(file_path=file_path, unique_id=None)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -118,6 +118,16 @@ class LocalTargetTest(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, obj)
 
+    def test_save_and_load_feather_without_store_index_in_feather(self):
+        obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]), index=pd.Index([33, 44], name='object_index')).reset_index()
+        file_path = os.path.join(_get_temporary_directory(), 'test.feather')
+
+        target = make_target(file_path=file_path, unique_id=None, store_index_in_feather=False)
+        target.dump(obj)
+        loaded = target.load()
+
+        pd.testing.assert_frame_equal(loaded, obj)
+
     def test_save_and_load_ini(self):
         obj = configparser.ConfigParser()
         obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': 2}
@@ -131,16 +141,6 @@ class LocalTargetTest(unittest.TestCase):
         loaded = target.load()
 
         self.assertEqual(loaded, obj)
-
-    def test_save_and_load_feather_without_store_index_in_feather(self):
-        obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]), index=pd.Index([33, 44], name='object_index')).reset_index()
-        file_path = os.path.join(_get_temporary_directory(), 'test.feather')
-
-        target = make_target(file_path=file_path, unique_id=None, store_index_in_feather=False)
-        target.dump(obj)
-        loaded = target.load()
-
-        pd.testing.assert_frame_equal(loaded, obj)
 
     def test_last_modified_time(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -130,7 +130,7 @@ class LocalTargetTest(unittest.TestCase):
 
     def test_save_and_load_config_file(self):
         obj = LuigiConfigParser()
-        obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': 2}
+        obj['common'] = {'a': '1', 'b': 'yes', 'c': 2}
         obj['example'] = {}
         obj['example']['d'] = 'foo'
         obj['example']['e'] = 'true'

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,3 +1,4 @@
+import configparser
 import io
 import os
 import shutil
@@ -116,6 +117,20 @@ class LocalTargetTest(unittest.TestCase):
         loaded = target.load()
 
         pd.testing.assert_frame_equal(loaded, obj)
+
+    def test_save_and_load_ini(self):
+        obj = configparser.ConfigParser()
+        obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': '2'}
+        obj['example'] = {}
+        obj['example']['d'] = 'foo'
+        obj['example']['e'] = 'bar'
+        file_path = os.path.join(_get_temporary_directory(), 'test.ini')
+
+        target = make_target(file_path=file_path, unique_id=None)
+        target.dump(obj)
+        loaded = target.load()
+
+        self.assertEqual(loaded, obj)
 
     def test_save_and_load_feather_without_store_index_in_feather(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]), index=pd.Index([33, 44], name='object_index')).reset_index()

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -128,30 +128,18 @@ class LocalTargetTest(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, obj)
 
-    def test_save_and_load_config_file(self):
+    def test_save_and_load_config_ini_file(self):
         obj = LuigiConfigParser()
         obj['common'] = {'a': '1', 'b': 'yes', 'c': 2}
         obj['example'] = {}
         obj['example']['d'] = 'foo'
         obj['example']['e'] = 'true'
-        file_path_ini = os.path.join(_get_temporary_directory(), 'test.ini')
-        file_path_cfg = os.path.join(_get_temporary_directory(), 'test.cfg')
-        file_path_conf = os.path.join(_get_temporary_directory(), 'test.conf')
+        file_path = os.path.join(_get_temporary_directory(), 'test.ini')
 
-        target_ini = make_target(file_path=file_path_ini, unique_id=None)
-        target_ini.dump(obj)
-        loaded_ini = target_ini.load()
-        self.assertEqual(loaded_ini, obj)
-
-        target_cfg = make_target(file_path=file_path_cfg, unique_id=None)
-        target_cfg.dump(obj)
-        loaded_cfg = target_cfg.load()
-        self.assertEqual(loaded_cfg, obj)
-
-        target_conf = make_target(file_path=file_path_conf, unique_id=None)
-        target_conf.dump(obj)
-        loaded_ini = target_conf.load()
-        self.assertEqual(loaded_ini, obj)
+        target = make_target(file_path=file_path, unique_id=None)
+        target.dump(obj)
+        loaded = target.load()
+        self.assertEqual(loaded, [str(obj)], msg='should save an object as List[str].')
 
     def test_last_modified_time(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import boto3
 import numpy as np
 import pandas as pd
-from luigi.configuration.cfg_parser import LuigiConfigParser
 from matplotlib import pyplot
 from moto import mock_s3
 
@@ -127,19 +126,6 @@ class LocalTargetTest(unittest.TestCase):
         loaded = target.load()
 
         pd.testing.assert_frame_equal(loaded, obj)
-
-    def test_save_and_load_config_ini_file(self):
-        obj = LuigiConfigParser()
-        obj['common'] = {'a': '1', 'b': 'yes', 'c': 2}
-        obj['example'] = {}
-        obj['example']['d'] = 'foo'
-        obj['example']['e'] = 'true'
-        file_path = os.path.join(_get_temporary_directory(), 'test.ini')
-
-        target = make_target(file_path=file_path, unique_id=None)
-        target.dump(obj)
-        loaded = target.load()
-        self.assertEqual(loaded, [str(obj)], msg='should save an object as List[str].')
 
     def test_last_modified_time(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -120,10 +120,10 @@ class LocalTargetTest(unittest.TestCase):
 
     def test_save_and_load_ini(self):
         obj = configparser.ConfigParser()
-        obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': '2'}
+        obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': 2}
         obj['example'] = {}
         obj['example']['d'] = 'foo'
-        obj['example']['e'] = 'bar'
+        obj['example']['e'] = True
         file_path = os.path.join(_get_temporary_directory(), 'test.ini')
 
         target = make_target(file_path=file_path, unique_id=None)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,4 +1,3 @@
-import configparser
 import io
 import os
 import shutil
@@ -9,6 +8,7 @@ from unittest.mock import patch
 import boto3
 import numpy as np
 import pandas as pd
+from luigi.configuration.cfg_parser import LuigiConfigParser
 from matplotlib import pyplot
 from moto import mock_s3
 
@@ -128,19 +128,30 @@ class LocalTargetTest(unittest.TestCase):
 
         pd.testing.assert_frame_equal(loaded, obj)
 
-    def test_save_and_load_ini(self):
-        obj = configparser.ConfigParser()
+    def test_save_and_load_config_file(self):
+        obj = LuigiConfigParser()
         obj['DEFAULT'] = {'a': '1', 'b': 'yes', 'c': 2}
         obj['example'] = {}
         obj['example']['d'] = 'foo'
         obj['example']['e'] = 'true'
-        file_path = os.path.join(_get_temporary_directory(), 'test.ini')
+        file_path_ini = os.path.join(_get_temporary_directory(), 'test.ini')
+        file_path_cfg = os.path.join(_get_temporary_directory(), 'test.cfg')
+        file_path_conf = os.path.join(_get_temporary_directory(), 'test.conf')
 
-        target = make_target(file_path=file_path, unique_id=None)
-        target.dump(obj)
-        loaded = target.load()
+        target_ini = make_target(file_path=file_path_ini, unique_id=None)
+        target_ini.dump(obj)
+        loaded_ini = target_ini.load()
+        self.assertEqual(loaded_ini, obj)
 
-        self.assertEqual(loaded, obj)
+        target_cfg = make_target(file_path=file_path_cfg, unique_id=None)
+        target_cfg.dump(obj)
+        loaded_cfg = target_cfg.load()
+        self.assertEqual(loaded_cfg, obj)
+
+        target_conf = make_target(file_path=file_path_conf, unique_id=None)
+        target_conf.dump(obj)
+        loaded_ini = target_conf.load()
+        self.assertEqual(loaded_ini, obj)
 
     def test_last_modified_time(self):
         obj = pd.DataFrame(dict(a=[1, 2], b=[3, 4]))


### PR DESCRIPTION
Add `.ini` file support for `file_processor`.

We use `TextFileProcessor` for `.ini` file.

In most cases with gokart, `.ini` files are used as config files, and there are some cases that requires you to just dump `.ini` config files, like [`kannon` library](https://github.com/m3dev/kannon) development.
`configparser` or `LuigiConfigParser` are seemingly suitable choices, but their functionality are sometimes overwhelming and there should be options on how to parse the loaded config files.
So, in order to achieve these kind of requirements, we use `TextFileProcessor` for `.ini` format. The loaded files are text, so users can choose how to parse them.
