### PR TITLE
Add cache existence check to wrap_with_run_lock

### DIFF
--- a/gokart/redis_lock.py
+++ b/gokart/redis_lock.py
@@ -94,12 +94,11 @@ def _wrap_with_lock(func, redis_params: RedisParams):
     return wrapper
 
 
-def wrap_with_run_lock(func, redis_params: RedisParams):
+def wrap_with_run_lock(func: Callable, redis_params: RedisParams, exist_check: Callable):
     """Redis lock wrapper function for RunWithLock.
-    When a fucntion is wrapped by RunWithLock, the wrapped function will be simply wrapped with redis lock.
-    https://github.com/m3dev/gokart/issues/265
+    When a fucntion is wrapped by RunWithLock, the wrapped function will be wrapped with redis lock and cache existance check.
     """
-    return _wrap_with_lock(func=func, redis_params=redis_params)
+    return wrap_with_dump_lock(func=func, redis_params=redis_params, exist_check=exist_check)
 
 
 def wrap_with_dump_lock(func: Callable, redis_params: RedisParams, exist_check: Callable):

--- a/gokart/run_with_lock.py
+++ b/gokart/run_with_lock.py
@@ -22,5 +22,5 @@ class RunWithLock:
             return func()
 
         output = output_list.pop()
-        wrapped_func = output.wrap_with_lock(func)
+        wrapped_func = output.wrap_with_run_lock(func)
         return cls._run_with_lock(func=wrapped_func, output_list=output_list)

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -44,8 +44,8 @@ class TargetOnKart(luigi.Target):
     def path(self) -> str:
         return self._path()
 
-    def wrap_with_lock(self, func):
-        return wrap_with_run_lock(func=func, redis_params=self._get_redis_params())
+    def wrap_with_run_lock(self, func):
+        return wrap_with_run_lock(func=func, redis_params=self._get_redis_params(), exist_check=self.exists)
 
     @abstractmethod
     def _exists(self) -> bool:

--- a/test/test_redis_lock.py
+++ b/test/test_redis_lock.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import fakeredis
 
-from gokart.redis_lock import RedisClient, RedisParams, make_redis_key, make_redis_params, wrap_with_dump_lock, wrap_with_remove_lock, wrap_with_run_lock
+from gokart.redis_lock import RedisClient, RedisParams, make_redis_key, make_redis_params, wrap_with_dump_lock, wrap_with_load_lock, wrap_with_remove_lock, wrap_with_run_lock
 
 
 class TestRedisClient(unittest.TestCase):
@@ -47,13 +47,12 @@ class TestWrapWithRunLock(unittest.TestCase):
             redis_port=None,
         )
         mock_func = MagicMock()
-        resulted = wrap_with_run_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
+        wrap_with_run_lock(func=mock_func, redis_params=redis_params, exist_check=lambda: False)(123, b='abc')
 
         mock_func.assert_called_once()
         called_args, called_kwargs = mock_func.call_args
         self.assertTupleEqual(called_args, (123, ))
         self.assertDictEqual(called_kwargs, dict(b='abc'))
-        self.assertEqual(resulted, mock_func())
 
     def test_use_redis(self):
         redis_params = make_redis_params(
@@ -66,13 +65,27 @@ class TestWrapWithRunLock(unittest.TestCase):
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             mock_func = MagicMock()
             redis_mock.side_effect = fakeredis.FakeRedis
-            resulted = wrap_with_run_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
+            wrap_with_run_lock(func=mock_func, redis_params=redis_params, exist_check=lambda: False)(123, b='abc')
 
             mock_func.assert_called_once()
             called_args, called_kwargs = mock_func.call_args
             self.assertTupleEqual(called_args, (123, ))
             self.assertDictEqual(called_kwargs, dict(b='abc'))
-            self.assertEqual(resulted, mock_func())
+
+    def test_if_func_is_skipped_when_cache_already_exists(self):
+        redis_params = make_redis_params(
+            file_path='test_dir/test_file.pkl',
+            unique_id='123abc',
+            redis_host='0.0.0.0',
+            redis_port=12345,
+        )
+
+        with patch('gokart.redis_lock.redis.Redis') as redis_mock:
+            redis_mock.side_effect = fakeredis.FakeRedis
+            mock_func = MagicMock()
+            wrap_with_run_lock(func=mock_func, redis_params=redis_params, exist_check=lambda: True)(123, b='abc')
+
+            mock_func.assert_not_called()
 
     def test_check_lock_extended(self):
         redis_params = make_redis_params(
@@ -86,9 +99,7 @@ class TestWrapWithRunLock(unittest.TestCase):
 
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.side_effect = fakeredis.FakeRedis
-            resulted = wrap_with_run_lock(func=_sample_long_func, redis_params=redis_params)(123, b='abc')
-            expected = dict(a=123, b='abc')
-            self.assertEqual(resulted, expected)
+            wrap_with_run_lock(func=_sample_long_func, redis_params=redis_params, exist_check=lambda: False)(123, b='abc')
 
     def test_lock_is_removed_after_func_is_finished(self):
         redis_params = make_redis_params(
@@ -103,13 +114,12 @@ class TestWrapWithRunLock(unittest.TestCase):
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.return_value = fakeredis.FakeRedis(server=server, host=redis_params.redis_host, port=redis_params.redis_port)
             mock_func = MagicMock()
-            resulted = wrap_with_run_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
+            wrap_with_run_lock(func=mock_func, redis_params=redis_params, exist_check=lambda: False)(123, b='abc')
 
             mock_func.assert_called_once()
             called_args, called_kwargs = mock_func.call_args
             self.assertTupleEqual(called_args, (123, ))
             self.assertDictEqual(called_kwargs, dict(b='abc'))
-            self.assertEqual(resulted, mock_func())
 
             fake_redis = fakeredis.FakeStrictRedis(server=server)
             with self.assertRaises(KeyError):
@@ -128,7 +138,7 @@ class TestWrapWithRunLock(unittest.TestCase):
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.return_value = fakeredis.FakeRedis(server=server, host=redis_params.redis_host, port=redis_params.redis_port)
             try:
-                wrap_with_run_lock(func=_sample_func_with_error, redis_params=redis_params)(a=123, b='abc')
+                wrap_with_run_lock(func=_sample_func_with_error, redis_params=redis_params, exist_check=lambda: False)(a=123, b='abc')
             except Exception:
                 fake_redis = fakeredis.FakeStrictRedis(server=server)
                 with self.assertRaises(KeyError):
@@ -253,7 +263,7 @@ class TestWrapWithLoadLock(unittest.TestCase):
             redis_port=None,
         )
         mock_func = MagicMock()
-        resulted = wrap_with_run_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
+        resulted = wrap_with_load_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
 
         mock_func.assert_called_once()
         called_args, called_kwargs = mock_func.call_args
@@ -273,7 +283,7 @@ class TestWrapWithLoadLock(unittest.TestCase):
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.side_effect = fakeredis.FakeRedis
             mock_func = MagicMock()
-            resulted = wrap_with_run_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
+            resulted = wrap_with_load_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
 
             mock_func.assert_called_once()
             called_args, called_kwargs = mock_func.call_args
@@ -294,7 +304,7 @@ class TestWrapWithLoadLock(unittest.TestCase):
 
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.side_effect = fakeredis.FakeRedis
-            resulted = wrap_with_run_lock(func=_sample_long_func, redis_params=redis_params)(123, b='abc')
+            resulted = wrap_with_load_lock(func=_sample_long_func, redis_params=redis_params)(123, b='abc')
             expected = dict(a=123, b='abc')
             self.assertEqual(resulted, expected)
 
@@ -311,7 +321,7 @@ class TestWrapWithLoadLock(unittest.TestCase):
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.return_value = fakeredis.FakeRedis(server=server, host=redis_params.redis_host, port=redis_params.redis_port)
             mock_func = MagicMock()
-            resulted = wrap_with_run_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
+            resulted = wrap_with_load_lock(func=mock_func, redis_params=redis_params)(123, b='abc')
 
             mock_func.assert_called_once()
             called_args, called_kwargs = mock_func.call_args
@@ -336,7 +346,7 @@ class TestWrapWithLoadLock(unittest.TestCase):
         with patch('gokart.redis_lock.redis.Redis') as redis_mock:
             redis_mock.return_value = fakeredis.FakeRedis(server=server, host=redis_params.redis_host, port=redis_params.redis_port)
             try:
-                wrap_with_run_lock(func=_sample_func_with_error, redis_params=redis_params)(123, b='abc')
+                wrap_with_load_lock(func=_sample_func_with_error, redis_params=redis_params)(123, b='abc')
             except Exception:
                 fake_redis = fakeredis.FakeStrictRedis(server=server)
                 with self.assertRaises(KeyError):

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -522,7 +522,7 @@ class TaskTest(unittest.TestCase):
         def _wrap(func):
             return func
 
-        with patch('gokart.target.TargetOnKart.wrap_with_lock') as mock_obj:
+        with patch('gokart.target.TargetOnKart.wrap_with_run_lock') as mock_obj:
             mock_obj.side_effect = _wrap
             task.run()
             mock_obj.assert_called_once()
@@ -533,7 +533,7 @@ class TaskTest(unittest.TestCase):
         def _wrap(func):
             return func
 
-        with patch('gokart.target.TargetOnKart.wrap_with_lock') as mock_obj:
+        with patch('gokart.target.TargetOnKart.wrap_with_run_lock') as mock_obj:
             mock_obj.side_effect = _wrap
             task.run()
             self.assertEqual(mock_obj.call_count, 2)
@@ -544,7 +544,7 @@ class TaskTest(unittest.TestCase):
         def _wrap(func):
             return func
 
-        with patch('gokart.target.TargetOnKart.wrap_with_lock') as mock_obj:
+        with patch('gokart.target.TargetOnKart.wrap_with_run_lock') as mock_obj:
             mock_obj.side_effect = _wrap
             task.run()
             mock_obj.assert_not_called()


### PR DESCRIPTION
## Changed feature
I've added cache existence check to wrap_with_run_lock

## What is wrap_with_run_lock?
wrap_with_run_lock is a wrapper function for TaskOnKart.run().
This is used to wrap TaskOnKart.run(), when you want to use efficient task cache collision lock https://gokart.readthedocs.io/en/latest/using_task_cache_collision_lock.html#advanced-using-efficient-task-cache-collision-lock 

## What is the problem of original code?
Suppose you are to run same task on different nodes at the same time.
- node1: TaskA
- node2: TaskA

In this case, node1 and node2 will do the same thing with the same result, which is inefficient.

By using efficient task cache collision lock,  TaskA.run() will not run at the same time.

However, in the original code, after node1 finished running TaskA, node2 will run TaskA again.
Cache collision will not happen, but this is still inefficient, because node2 didn't need to run TaskA again.

## How to overcome this problem?
I've added cache existence check just before TaskOnKart.run() to prevent running run() again.
When the cache file is found at the runtime, run() will be skipped.