### PR TITLE
gokart.build(reset_register=False) can use PandasTypeConfig

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import Any, Optional
 
 import luigi
+import gokart
 
 from gokart.task import TaskOnKart
 
@@ -38,8 +39,12 @@ def _get_output(task: TaskOnKart) -> Any:
 
 
 def _reset_register(keep={'gokart', 'luigi'}):
-    luigi.task_register.Register._reg = [x for x in luigi.task_register.Register._reg
-                                         if x.__module__.split('.')[0] in keep]  # avoid TaskClassAmbigiousException
+    """reset luigi.task_register.Register._reg everytime gokart.build called to avoid TaskClassAmbigiousException"""
+    luigi.task_register.Register._reg = [
+        x for x in luigi.task_register.Register._reg if ((x.__module__.split('.')[0] in keep)  # keep luigi and gokart
+                                                         or (issubclass(x, gokart.PandasTypeConfig))  # PandasTypeConfig should be kept
+                                                         )
+    ]
 
 
 def build(task: TaskOnKart, return_value: bool = True, reset_register: bool = True, log_level: int = logging.ERROR, **env_params) -> Optional[Any]:

--- a/gokart/build.py
+++ b/gokart/build.py
@@ -3,8 +3,8 @@ from logging import getLogger
 from typing import Any, Optional
 
 import luigi
-import gokart
 
+import gokart
 from gokart.task import TaskOnKart
 
 
@@ -42,8 +42,7 @@ def _reset_register(keep={'gokart', 'luigi'}):
     """reset luigi.task_register.Register._reg everytime gokart.build called to avoid TaskClassAmbigiousException"""
     luigi.task_register.Register._reg = [
         x for x in luigi.task_register.Register._reg if ((x.__module__.split('.')[0] in keep)  # keep luigi and gokart
-                                                         or (issubclass(x, gokart.PandasTypeConfig))  # PandasTypeConfig should be kept
-                                                         )
+                                                         or (issubclass(x, gokart.PandasTypeConfig)))  # PandasTypeConfig should be kept
     ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ types-redis = "*"
 [tool.flake8]
 # B006: Do not use mutable data structures for argument defaults. They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
 # B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
-ignore = "B006,B008"
+# W503 line break before binary operator. We use W504(line break after binary operator) rather than W503
+ignore = "B006,B008,W503"
 max-line-length = 160
 exclude = "venv/*,tox/*"
 

--- a/test/test_pandas_type_check_framework.py
+++ b/test/test_pandas_type_check_framework.py
@@ -69,8 +69,7 @@ class TestPandasTypeCheckFramework(unittest.TestCase):
         luigi.setup_logging.DaemonLogging._configured = False
         luigi.setup_logging.InterfaceLogging._configured = False
 
-
-    @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummyFailTask', '--log-level=CRITICAL', '--local-scheduler',  '--no-lock'])
+    @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummyFailTask', '--log-level=CRITICAL', '--local-scheduler', '--no-lock'])
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
     def test_fail_with_gokart_run(self):
         with self.assertRaises(SystemExit) as exit_code:
@@ -78,13 +77,19 @@ class TestPandasTypeCheckFramework(unittest.TestCase):
         self.assertNotEqual(exit_code.exception.code, 0)  # raise Error
 
     def test_fail(self):
+        original_reg = luigi.task_register.Register._reg
         with self.assertRaises(GokartBuildError):
             gokart.build(_DummyFailTask())
+        luigi.task_register.Register._reg = original_reg
 
     def test_fail_with_None(self):
+        original_reg = luigi.task_register.Register._reg
         with self.assertRaises(GokartBuildError):
             gokart.build(_DummyFailWithNoneTask())
+        luigi.task_register.Register._reg = original_reg
 
     def test_success(self):
+        original_reg = luigi.task_register.Register._reg
         gokart.build(_DummySuccessTask())
         # no error
+        luigi.task_register.Register._reg = original_reg

--- a/test/test_pandas_type_check_framework.py
+++ b/test/test_pandas_type_check_framework.py
@@ -2,13 +2,13 @@ import unittest
 from logging import getLogger
 from typing import Any, Dict
 from unittest.mock import patch
-from gokart.build import GokartBuildError
 
 import luigi
 import pandas as pd
 from luigi.mock import MockFileSystem, MockTarget
 
 import gokart
+from gokart.build import GokartBuildError
 from gokart.pandas_type_config import PandasTypeConfig
 
 logger = getLogger(__name__)

--- a/test/test_pandas_type_check_framework.py
+++ b/test/test_pandas_type_check_framework.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 from logging import getLogger
 from typing import Any, Dict
@@ -81,11 +82,11 @@ class TestPandasTypeCheckFramework(unittest.TestCase):
 
     def test_fail(self):
         with self.assertRaises(GokartBuildError):
-            gokart.build(_DummyFailTask())
+            gokart.build(_DummyFailTask(), log_level=logging.CRITICAL)
 
     def test_fail_with_None(self):
         with self.assertRaises(GokartBuildError):
-            gokart.build(_DummyFailWithNoneTask())
+            gokart.build(_DummyFailWithNoneTask(), log_level=logging.CRITICAL)
 
     def test_success(self):
         gokart.build(_DummySuccessTask())

--- a/test/test_pandas_type_check_framework.py
+++ b/test/test_pandas_type_check_framework.py
@@ -2,6 +2,7 @@ import unittest
 from logging import getLogger
 from typing import Any, Dict
 from unittest.mock import patch
+from gokart.build import GokartBuildError
 
 import luigi
 import pandas as pd
@@ -68,23 +69,22 @@ class TestPandasTypeCheckFramework(unittest.TestCase):
         luigi.setup_logging.DaemonLogging._configured = False
         luigi.setup_logging.InterfaceLogging._configured = False
 
-    @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummyFailTask', '--log-level=CRITICAL', '--local-scheduler', '--no-lock'])
+
+    @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummyFailTask', '--log-level=CRITICAL', '--local-scheduler',  '--no-lock'])
     @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
+    def test_fail_with_gokart_run(self):
+        with self.assertRaises(SystemExit) as exit_code:
+            gokart.run()
+        self.assertNotEqual(exit_code.exception.code, 0)  # raise Error
+
     def test_fail(self):
-        with self.assertRaises(SystemExit) as exit_code:
-            gokart.run()
-        self.assertNotEqual(exit_code.exception.code, 0)  # raise Error
+        with self.assertRaises(GokartBuildError):
+            gokart.build(_DummyFailTask())
 
-    @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummyFailWithNoneTask', '--log-level=CRITICAL', '--local-scheduler', '--no-lock'])
-    @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
     def test_fail_with_None(self):
-        with self.assertRaises(SystemExit) as exit_code:
-            gokart.run()
-        self.assertNotEqual(exit_code.exception.code, 0)  # raise Error
+        with self.assertRaises(GokartBuildError):
+            gokart.build(_DummyFailWithNoneTask())
 
-    @patch('sys.argv', new=['main', 'test_pandas_type_check_framework._DummySuccessTask', '--log-level=CRITICAL', '--local-scheduler', '--no-lock'])
-    @patch('luigi.LocalTarget', new=lambda path, **kwargs: MockTarget(path, **kwargs))
     def test_success(self):
-        with self.assertRaises(SystemExit) as exit_code:
-            gokart.run()
-        self.assertEqual(exit_code.exception.code, 0)
+        gokart.build(_DummySuccessTask())
+        # no error


### PR DESCRIPTION
By default, gokart.build() resets Register. So PandasTypeConfig is also ignored.

This PR keeps PandasTypeConfig even if reset_register=True.