### PR TITLE
Change build backend to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ quote-style = "single"
 ignore_missing_imports = true
 
 [build-system]
-requires = ["poetry"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
poetry-core is PEP 517 build backend of poetry

https://github.com/python-poetry/poetry-core

> A PEP 517 build backend implementation developed for Poetry. This project is intended to be a lightweight, fully compliant, self-contained package allowing PEP 517-compatible build frontends to build Poetry-managed projects.

## Backgroud

We would like to try developing version of gokart

but `poetry add git+ssh://git@github.com:m3dev/gokart.git` will break original version constraints (e.g. gokart > 1.0.0) because of use of `poetry-dynamic-versioning`.

With poetry-core, we can `poetry add git+ssh://git@github.com:m3dev/gokart.git --editable`, which run  `poetry-dynamic-versioning` while installing.

## Side Effect

I believe no side effect. Actually, current default backend is already poetry-core https://python-poetry.org/docs/basic-usage/ .