### PR TITLE
add type aware flatten method instead of `luigi.task.flatten`

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -11,6 +11,7 @@ import pandas as pd
 from luigi.parameter import ParameterVisibility
 
 import gokart
+import gokart.target
 from gokart.conflict_prevention_lock.task_lock import make_task_lock_params, make_task_lock_params_for_run
 from gokart.conflict_prevention_lock.task_lock_wrappers import wrap_run_with_lock
 from gokart.file_processor import FileProcessor
@@ -18,6 +19,7 @@ from gokart.pandas_type_config import PandasTypeConfigMap
 from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.target import TargetOnKart
 from gokart.task_complete_check import task_complete_check_wrapper
+from gokart.utils import FlattableItems, flatten
 
 logger = getLogger(__name__)
 
@@ -103,10 +105,13 @@ class TaskOnKart(luigi.Task):
             task_lock_params = make_task_lock_params_for_run(task_self=self)
             self.run = wrap_run_with_lock(run_func=self.run, task_lock_params=task_lock_params)
 
-    def output(self):
+    def input(self) -> FlattableItems[TargetOnKart]:
+        return super().input()
+
+    def output(self) -> FlattableItems[TargetOnKart]:
         return self.make_target()
 
-    def requires(self):
+    def requires(self) -> FlattableItems['TaskOnKart']:
         tasks = self.make_task_instance_dictionary()
         return tasks or []  # when tasks is empty dict, then this returns empty list.
 
@@ -130,16 +135,16 @@ class TaskOnKart(luigi.Task):
 
     def complete(self) -> bool:
         if self._rerun_state:
-            for target in luigi.task.flatten(self.output()):
+            for target in flatten(self.output()):
                 target.remove()
             self._rerun_state = False
             return False
 
-        is_completed = all([t.exists() for t in luigi.task.flatten(self.output())])
+        is_completed = all([t.exists() for t in flatten(self.output())])
 
         if self.strict_check or self.modification_time_check:
-            requirements = luigi.task.flatten(self.requires())
-            inputs = luigi.task.flatten(self.input())
+            requirements = flatten(self.requires())
+            inputs = flatten(self.input())
             is_completed = is_completed and all([task.complete() for task in requirements]) and all([i.exists() for i in inputs])
 
         if not self.modification_time_check or not is_completed or not self.input():
@@ -148,9 +153,9 @@ class TaskOnKart(luigi.Task):
         return self._check_modification_time()
 
     def _check_modification_time(self):
-        common_path = set(t.path() for t in luigi.task.flatten(self.input())) & set(t.path() for t in luigi.task.flatten(self.output()))
-        input_tasks = [t for t in luigi.task.flatten(self.input()) if t.path() not in common_path]
-        output_tasks = [t for t in luigi.task.flatten(self.output()) if t.path() not in common_path]
+        common_path = set(t.path() for t in flatten(self.input())) & set(t.path() for t in flatten(self.output()))
+        input_tasks = [t for t in flatten(self.input()) if t.path() not in common_path]
+        output_tasks = [t for t in flatten(self.output()) if t.path() not in common_path]
 
         input_modification_time = max([target.last_modification_time() for target in input_tasks]) if input_tasks else None
         output_modification_time = min([target.last_modification_time() for target in output_tasks]) if output_tasks else None
@@ -334,7 +339,7 @@ class TaskOnKart(luigi.Task):
 
             return task.to_str_params(only_significant=True)
 
-        dependencies = [_to_str_params(task) for task in luigi.task.flatten(self.requires())]
+        dependencies = [_to_str_params(task) for task in flatten(self.requires())]
         dependencies = [d for d in dependencies if d is not None]
         dependencies.append(self.to_str_params(only_significant=True))
         dependencies.append(self.__class__.__name__)
@@ -342,18 +347,27 @@ class TaskOnKart(luigi.Task):
             dependencies.append(self.get_own_code())
         return hashlib.md5(str(dependencies).encode()).hexdigest()
 
-    def _get_input_targets(self, target: Union[None, str, TargetOnKart]) -> Union[TargetOnKart, List[TargetOnKart]]:
+    def _get_input_targets(self, target: Union[None, str, TargetOnKart]) -> FlattableItems[TargetOnKart]:
         if target is None:
             return self.input()
         if isinstance(target, str):
-            return self.input()[target]
+            input = self.input()
+            assert isinstance(input, dict), f'input must be dict[str, TargetOnKart], but {type(input)} is passed.'
+            result: FlattableItems[TargetOnKart] = input[target]
+            return result
         return target
 
     def _get_output_target(self, target: Union[None, str, TargetOnKart]) -> TargetOnKart:
         if target is None:
-            return self.output()
+            output = self.output()
+            assert isinstance(output, TargetOnKart), f'output must be TargetOnKart, but {type(output)} is passed.'
+            return output
         if isinstance(target, str):
-            return self.output()[target]
+            output = self.output()
+            assert isinstance(output, dict), f'output must be dict[str, TargetOnKart], but {type(output)} is passed.'
+            result = output[target]
+            assert isinstance(result, TargetOnKart), f'output must be dict[str, TargetOnKart], but {type(output)} is passed.'
+            return result
         return target
 
     def get_info(self, only_significant=False):
@@ -380,7 +394,7 @@ class TaskOnKart(luigi.Task):
 
     @luigi.Task.event_handler(luigi.Event.SUCCESS)
     def _dump_task_log(self):
-        self.task_log['file_path'] = [target.path() for target in luigi.task.flatten(self.output())]
+        self.task_log['file_path'] = [target.path() for target in flatten(self.output())]
         if self.should_dump_supplementary_log_files:
             self.dump(self.task_log, self._get_task_log_target())
 

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -19,7 +19,7 @@ from gokart.pandas_type_config import PandasTypeConfigMap
 from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.target import TargetOnKart
 from gokart.task_complete_check import task_complete_check_wrapper
-from gokart.utils import FlattableItems, flatten
+from gokart.utils import FlattenableItems, flatten
 
 logger = getLogger(__name__)
 
@@ -105,13 +105,13 @@ class TaskOnKart(luigi.Task):
             task_lock_params = make_task_lock_params_for_run(task_self=self)
             self.run = wrap_run_with_lock(run_func=self.run, task_lock_params=task_lock_params)
 
-    def input(self) -> FlattableItems[TargetOnKart]:
+    def input(self) -> FlattenableItems[TargetOnKart]:
         return super().input()
 
-    def output(self) -> FlattableItems[TargetOnKart]:
+    def output(self) -> FlattenableItems[TargetOnKart]:
         return self.make_target()
 
-    def requires(self) -> FlattableItems['TaskOnKart']:
+    def requires(self) -> FlattenableItems['TaskOnKart']:
         tasks = self.make_task_instance_dictionary()
         return tasks or []  # when tasks is empty dict, then this returns empty list.
 
@@ -347,13 +347,13 @@ class TaskOnKart(luigi.Task):
             dependencies.append(self.get_own_code())
         return hashlib.md5(str(dependencies).encode()).hexdigest()
 
-    def _get_input_targets(self, target: Union[None, str, TargetOnKart]) -> FlattableItems[TargetOnKart]:
+    def _get_input_targets(self, target: Union[None, str, TargetOnKart]) -> FlattenableItems[TargetOnKart]:
         if target is None:
             return self.input()
         if isinstance(target, str):
             input = self.input()
             assert isinstance(input, dict), f'input must be dict[str, TargetOnKart], but {type(input)} is passed.'
-            result: FlattableItems[TargetOnKart] = input[target]
+            result: FlattenableItems[TargetOnKart] = input[target]
             return result
         return target
 

--- a/gokart/testing/check_if_run_with_empty_data_frame.py
+++ b/gokart/testing/check_if_run_with_empty_data_frame.py
@@ -7,6 +7,7 @@ import pandas as pd
 from luigi.cmdline_parser import CmdlineParser
 
 import gokart
+from gokart.utils import flatten
 
 test_logger = logging.getLogger(__name__)
 test_logger.addHandler(logging.StreamHandler())
@@ -39,7 +40,10 @@ class _TestStatus:
 
 
 def _get_all_tasks(task: gokart.TaskOnKart) -> List[gokart.TaskOnKart]:
-    return luigi.task.flatten([_get_all_tasks(o) for o in luigi.task.flatten(task.requires()) if isinstance(o, gokart.TaskOnKart)] + [task])
+    result = [task]
+    for o in flatten(task.requires()):
+        result.extend(_get_all_tasks(o))
+    return result
 
 
 def _run_with_test_status(task: gokart.TaskOnKart):

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -1,11 +1,10 @@
 import typing
 import warnings
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Optional, Set, Union
-
-import luigi
+from typing import Dict, List, NamedTuple, Optional, Set
 
 from gokart.task import TaskOnKart
+from gokart.utils import FlattableItems, flatten
 
 
 @dataclass
@@ -17,7 +16,7 @@ class TaskInfo:
     processing_time: str
     is_complete: str
     task_log: dict
-    requires: Union['RequiredTask', List['RequiredTask'], Dict[str, 'RequiredTask']]
+    requires: FlattableItems['RequiredTask']
     children_task_infos: List['TaskInfo']
 
     def get_task_id(self):
@@ -65,7 +64,7 @@ def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]
 
     name = task.__class__.__name__
     unique_id = task.make_unique_id()
-    output_paths: List[str] = [t.path() for t in luigi.task.flatten(task.output())]
+    output_paths: List[str] = [t.path() for t in flatten(task.output())]
 
     cache = {} if cache is None else cache
     cache_id = f'{name}_{unique_id}_{is_task_complete}'
@@ -80,7 +79,7 @@ def make_task_info_tree(task: TaskOnKart, ignore_task_names: Optional[List[str]]
     task_log = dict(task.get_task_log())
     requires = _make_requires_info(task.requires())
 
-    children = luigi.task.flatten(task.requires())
+    children = flatten(task.requires())
     children_task_infos: List[TaskInfo] = []
     for child in children:
         if ignore_task_names is None or child.__class__.__name__ not in ignore_task_names:

--- a/gokart/tree/task_info_formatter.py
+++ b/gokart/tree/task_info_formatter.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, Optional, Set
 
 from gokart.task import TaskOnKart
-from gokart.utils import FlattableItems, flatten
+from gokart.utils import FlattenableItems, flatten
 
 
 @dataclass
@@ -16,7 +16,7 @@ class TaskInfo:
     processing_time: str
     is_complete: str
     task_log: dict
-    requires: FlattableItems['RequiredTask']
+    requires: FlattenableItems['RequiredTask']
     children_task_infos: List['TaskInfo']
 
     def get_task_id(self):

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -38,6 +38,8 @@ def flatten(targets: FlattenableItems[T]) -> list[T]:
         ['foo']
         >>> flatten(42)
         [42]
+
+    This method is copied and modified from [luigi.task.flatten](https://github.com/spotify/luigi/blob/367edc2e3a099b8a0c2d15b1676269e33ad06117/luigi/task.py#L958) in accordance with [Apache License 2.0](https://github.com/spotify/luigi/blob/367edc2e3a099b8a0c2d15b1676269e33ad06117/LICENSE).
     """
     if targets is None:
         return []

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable, TypeAlias, TypeVar
+import sys
+from typing import Iterable, TypeVar
 
 import luigi
 
@@ -13,7 +14,14 @@ def add_config(file_path: str):
 
 
 T = TypeVar('T')
-FlattableItems: TypeAlias = T | Iterable['FlattableItems[T]'] | dict[str, 'FlattableItems[T]']
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+
+    FlattableItems: TypeAlias = T | Iterable['FlattableItems[T]'] | dict[str, 'FlattableItems[T]']
+else:
+    from typing import Union
+
+    FlattableItems = Union[T, Iterable['FlattableItems[T]'], dict[str, 'FlattableItems[T]']]
 
 
 def flatten(targets: FlattableItems[T]) -> list[T]:

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -17,14 +17,14 @@ T = TypeVar('T')
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
 
-    FlattableItems: TypeAlias = T | Iterable['FlattableItems[T]'] | dict[str, 'FlattableItems[T]']
+    FlattenableItems: TypeAlias = T | Iterable['FlattenableItems[T]'] | dict[str, 'FlattenableItems[T]']
 else:
     from typing import Union
 
-    FlattableItems = Union[T, Iterable['FlattableItems[T]'], dict[str, 'FlattableItems[T]']]
+    FlattenableItems = Union[T, Iterable['FlattenableItems[T]'], dict[str, 'FlattenableItems[T]']]
 
 
-def flatten(targets: FlattableItems[T]) -> list[T]:
+def flatten(targets: FlattenableItems[T]) -> list[T]:
     """
     Creates a flat list of all items in structured output (dicts, lists, items):
 

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import os
+from typing import Iterable, TypeAlias, TypeVar
 
 import luigi
 
@@ -7,3 +10,41 @@ def add_config(file_path: str):
     _, ext = os.path.splitext(file_path)
     luigi.configuration.core.parser = ext
     assert luigi.configuration.add_config_path(file_path)
+
+
+T = TypeVar('T')
+FlattableItems: TypeAlias = T | Iterable['FlattableItems[T]'] | dict[str, 'FlattableItems[T]']
+
+
+def flatten(targets: FlattableItems[T]) -> list[T]:
+    """
+    Creates a flat list of all items in structured output (dicts, lists, items):
+
+    .. code-block:: python
+
+        >>> sorted(flatten({'a': 'foo', 'b': 'bar'}))
+        ['bar', 'foo']
+        >>> sorted(flatten(['foo', ['bar', 'troll']]))
+        ['bar', 'foo', 'troll']
+        >>> flatten('foo')
+        ['foo']
+        >>> flatten(42)
+        [42]
+    """
+    if targets is None:
+        return []
+    flat = []
+    if isinstance(targets, dict):
+        for _, result in targets.items():
+            flat += flatten(result)
+        return flat
+
+    if isinstance(targets, str):
+        return [targets]  # type: ignore
+
+    if not isinstance(targets, Iterable):
+        return [targets]
+
+    for result in targets:
+        flat += flatten(result)
+    return flat

--- a/gokart/workspace_management.py
+++ b/gokart/workspace_management.py
@@ -3,16 +3,15 @@ import os
 import pathlib
 from logging import getLogger
 
-import luigi
-
 import gokart
+from gokart.utils import flatten
 
 logger = getLogger(__name__)
 
 
 def _get_all_output_file_paths(task: gokart.TaskOnKart):
-    output_paths = [t.path() for t in luigi.task.flatten(task.output())]
-    children = luigi.task.flatten(task.requires())
+    output_paths = [t.path() for t in flatten(task.output())]
+    children = flatten(task.requires())
     output_paths.extend(itertools.chain.from_iterable([_get_all_output_file_paths(child) for child in children]))
     return output_paths
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,20 @@
+import unittest
+
+from gokart.utils import flatten
+
+
+class TestFlatten(unittest.TestCase):
+    def test_flatten_dict(self):
+        self.assertEqual(flatten({'a': 'foo', 'b': 'bar'}), ['foo', 'bar'])
+
+    def test_flatten_list(self):
+        self.assertEqual(flatten(['foo', ['bar', 'troll']]), ['foo', 'bar', 'troll'])
+
+    def test_flatten_str(self):
+        self.assertEqual(flatten('foo'), ['foo'])
+
+    def test_flatten_int(self):
+        self.assertEqual(flatten(42), [42])
+
+    def test_flatten_none(self):
+        self.assertEqual(flatten(None), [])


### PR DESCRIPTION
Currently, we use `luigi.task.flatten`, but this method is not type aware (it return type is always `Unknown`. Because of this, we wrote missed type [here](https://github.com/m3dev/gokart/blob/837742d/gokart/tree/task_info_formatter.py?plain=1#L15) ( it should be `List[str]`, but `List[TaskOnKart]` ). 

So, I introduce type aware flatten method instead of `luigi.task.flatten`