### PR TITLE
setting priority random

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -1,6 +1,7 @@
 import hashlib
 import inspect
 import os
+import random
 import types
 from importlib import import_module
 from logging import getLogger
@@ -85,6 +86,10 @@ class TaskOnKart(luigi.Task):
         default=True, description='Check if output file exists at run. If exists, run() will be skipped.', significant=False
     )
     should_lock_run: bool = ExplicitBoolParameter(default=False, significant=False, description='Whether to use redis lock or not at task run.')
+
+    @property
+    def priority(self):
+        return random.Random().random()  # seed is fixed, so we need to use random.Random().random() instead f random.random()
 
     def __init__(self, *args, **kwargs):
         self._add_configuration(kwargs, 'TaskOnKart')


### PR DESCRIPTION
Changing priority randomly to sort the order of task scheduling randomly.

This is useful when jobs are running in parallel.
Together with the complete check function during run (complete_check_at_run; default True), it will speeds up parallel execution, because each job will run different task in different order and same tasks will not be ran.

The disadvantage is that the order of execution is scattered, so it changes a little each time when looking at the log.