### PR TITLE
fix load_dill_with_pandas_backward_compatibility() bug

### DIFF
--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -82,7 +82,7 @@ class PickleFileProcessor(FileProcessor):
         return luigi.format.Nop
 
     def load(self, file):
-        if not ObjectStorage.is_buffered_reader(file):
+        if not ObjectStorage.is_buffered_reader(file) or not file.seekable():
             # we cannot use dill.load(file) because ReadableS3File does not have 'readline' method
             return load_dill_with_pandas_backward_compatibility(BytesIO(file.read()))
         return load_dill_with_pandas_backward_compatibility(_ChunkedLargeFileReader(file))

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -82,8 +82,8 @@ class PickleFileProcessor(FileProcessor):
         return luigi.format.Nop
 
     def load(self, file):
-        if not ObjectStorage.is_buffered_reader(file) or not file.seekable():
-            # we cannot use dill.load(file) because ReadableS3File does not have 'readline' method
+        if not file.seekable():
+            # ReadableS3File is not seekable, therefor we need to wrap with BytesIO
             return load_dill_with_pandas_backward_compatibility(BytesIO(file.read()))
         return load_dill_with_pandas_backward_compatibility(_ChunkedLargeFileReader(file))
 

--- a/gokart/file_processor.py
+++ b/gokart/file_processor.py
@@ -83,7 +83,9 @@ class PickleFileProcessor(FileProcessor):
 
     def load(self, file):
         if not file.seekable():
-            # ReadableS3File is not seekable, therefor we need to wrap with BytesIO
+            # load_dill_with_pandas_backward_compatibility() requires file with seek() and readlines() implemented.
+            # Therefore, we need to wrap with BytesIO which makes file seekable and readlinesable.
+            # For example, ReadableS3File is not a seekable file.
             return load_dill_with_pandas_backward_compatibility(BytesIO(file.read()))
         return load_dill_with_pandas_backward_compatibility(_ChunkedLargeFileReader(file))
 

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -14,6 +14,8 @@ class FileLike(Protocol):
 
     def readline(self) -> bytes: ...
 
+    def seek(self, offset: int) -> None: ...
+
 
 def add_config(file_path: str):
     _, ext = os.path.splitext(file_path)

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -76,4 +76,5 @@ def load_dill_with_pandas_backward_compatibility(file: FileLike) -> Any:
     try:
         return pd.read_pickle(file)
     except Exception:
+        file.seek(0)
         return dill.load(file)

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -76,7 +76,7 @@ def load_dill_with_pandas_backward_compatibility(file: FileLike) -> Any:
     It is unclear whether all objects dumped by dill can be loaded by pd.read_pickle, we use dill.load as a fallback.
     """
     try:
-        return pd.read_pickle(file)
+        return dill.load(file)
     except Exception:
         file.seek(0)
-        return dill.load(file)
+        return pd.read_pickle(file)

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -16,6 +16,8 @@ class FileLike(Protocol):
 
     def seek(self, offset: int) -> None: ...
 
+    def seekable(self) -> bool: ...
+
 
 def add_config(file_path: str):
     _, ext = os.path.splitext(file_path)
@@ -29,8 +31,6 @@ if sys.version_info >= (3, 10):
 
     FlattenableItems: TypeAlias = T | Iterable['FlattenableItems[T]'] | dict[str, 'FlattenableItems[T]']
 else:
-    from typing import Union
-
     FlattenableItems = Union[T, Iterable['FlattenableItems[T]'], dict[str, 'FlattenableItems[T]']]
 
 

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -78,5 +78,6 @@ def load_dill_with_pandas_backward_compatibility(file: FileLike) -> Any:
     try:
         return dill.load(file)
     except Exception:
+        assert file.seekable(), f'{file} is not seekable.'
         file.seek(0)
         return pd.read_pickle(file)


### PR DESCRIPTION
When `pd.read_pickle(file)` failed, load_dill_with_pandas_backward_compatibility() will fall back and use `dill.load(file)`.

But before loading with dill, file cursor must be rewind to the beginning.