### PR TITLE
Add TaskOnKart load type

### DIFF
--- a/docs/for_pandas.rst
+++ b/docs/for_pandas.rst
@@ -25,7 +25,7 @@ Pandas has a feature that converts the type of column(s) automatically. This fea
             return {'int_column': int}
 
 
-    class SampleTask(gokart.TaskOnKart):
+    class SampleTask(gokart.TaskOnKart[pd.DataFrame]):
 
         def run(self):
             # [PandasTypeError] because expected type is `int`, but `str` is passed.

--- a/docs/intro_to_gokart.rst
+++ b/docs/intro_to_gokart.rst
@@ -23,7 +23,7 @@ A minimal gokart tasks looks something like this:
 
     import gokart
 
-    class Example(gokart.TaskOnKart):
+    class Example(gokart.TaskOnKart[str]):
         def run(self):
             self.dump('Hello, world!')
 
@@ -61,7 +61,7 @@ A minimal gokart tasks looks something like this:
             └── Example_8441c59b5ce0113396d53509f19371fb.pkl
 
 
-The result of dumping the task will be saved in the ``__name__`` directory. 
+The result of dumping the task will be saved in the ``__name__`` directory.
 
 
 .. code:: python
@@ -108,7 +108,7 @@ The :func:`~gokart.run` is running on shell.
     import gokart
     import luigi
 
-    class SampleTask(gokart.TaskOnKart):
+    class SampleTask(gokart.TaskOnKart[str]):
         param = luigi.Parameter()
 
         def run(self):
@@ -140,7 +140,7 @@ The :func:`~gokart.build` is inline code.
     import gokart
     import luigi
 
-    class SampleTask(gokart.TaskOnKart):
+    class SampleTask(gokart.TaskOnKart[str]):
         param = luigi.Parameter()
 
         def run(self):

--- a/docs/mypy_plugin.rst
+++ b/docs/mypy_plugin.rst
@@ -23,6 +23,9 @@ or by adding the following to your ``pyproject.toml`` file:
 
 Then, run Mypy as usual.
 
+Examples
+--------
+
 For example the following code linted by Mypy:
 
 .. code:: python
@@ -40,3 +43,24 @@ For example the following code linted by Mypy:
 
     Foo(foo=1, bar='2')   # OK
     Foo(foo='1') # NG because foo is not int and bar is missing
+
+
+Mypy plugin checks TaskOnKart generic types.
+
+.. code:: python
+
+    class SampleTask(gokart.TaskOnKart):
+        str_task: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
+        int_task: gokart.TaskOnKart[int] = gokart.TaskInstanceParameter()
+
+        def requires(self):
+            return dict(str=self.str_task, int=self.int_task)
+
+        def run(self):
+            s = self.load(self.str_task)  # This type is inferred with "str"
+            i = self.load(self.int_task)  # This type is inferred with "int"
+
+    SampleTask(
+        str_task=StrTask(),  # mypy ok
+        int_task=StrTask(),  # mypy error: Argument "int_task" to "StrTask" has incompatible type "StrTask"; expected "TaskOnKart[int]
+    )

--- a/docs/task_information.rst
+++ b/docs/task_information.rst
@@ -96,26 +96,26 @@ example
     import luigi
     import gokart
 
-    class TaskA(gokart.TaskOnKart):
+    class TaskA(gokart.TaskOnKart[str]):
         param = luigi.Parameter()
         def run(self):
             self.dump(f'{self.param}')
 
-    class TaskB(gokart.TaskOnKart):
-        task = gokart.TaskInstanceParameter()
+    class TaskB(gokart.TaskOnKart[str]):
+        task: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
         def run(self):
             task = self.load('task')
             self.dump(task + ' taskB')
 
-    class TaskC(gokart.TaskOnKart):
-        task = gokart.TaskInstanceParameter()
+    class TaskC(gokart.TaskOnKart[str]):
+        task: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
         def run(self):
             task = self.load('task')
             self.dump(task + ' taskC')
 
     class TaskD(gokart.TaskOnKart):
-        task1 = gokart.TaskInstanceParameter()
-        task2 = gokart.TaskInstanceParameter()
+        task1: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
+        task2: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
         def run(self):
             task = [self.load('task1'), self.load('task2')]
             self.dump(','.join(task))
@@ -181,7 +181,7 @@ This table contains `task name`, `cache unique id`, `cache file path`, `task par
     #     List of task names to ignore.
     # Returns
     # -------
-    # - task_info_table : pandas.DataFrame 
+    # - task_info_table : pandas.DataFrame
     #     Formatted task dependency table.
     # """
 
@@ -273,4 +273,3 @@ the output could be like:
 Delete Unnecessary Output Files
 --------------------------------
 To delete output files which are not necessary to run a task, add option ``--delete-unnecessary-output-files``. This option is supported only when a task outputs files in local storage not S3 for now.
-

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -16,7 +16,7 @@ How ``TaskOnKart`` helps to define a task looks like:
     import gokart
 
 
-    class TaskA(gokart.TaskOnKart):
+    class TaskA(gokart.TaskOnKart[str]):
         param = luigi.Parameter()
 
         def output(self):
@@ -27,7 +27,7 @@ How ``TaskOnKart`` helps to define a task looks like:
             self.dump(results)
 
 
-    class TaskB(gokart.TaskOnKart):
+    class TaskB(gokart.TaskOnKart[str]):
         param = luigi.Parameter()
 
         def requires(self):
@@ -215,7 +215,7 @@ The :func:`~gokart.task.TaskOnKart.make_model_target` method is used to dump for
 
     import gensim
 
-    class TrainWord2Vec(gokart.TaskOnKart):
+    class TrainWord2Vec(gokart.TaskOnKart[Word2VecResult]):
         def output(self):
             # please use 'zip'.
             return self.make_model_target(
@@ -256,7 +256,7 @@ Note that when set to False, task_info functions (e.g. gokart.tree.task_info.mak
 Dump csv with encoding
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can dump csv file by implementing `Task.output()` method as follows: 
+You can dump csv file by implementing `Task.output()` method as follows:
 
 .. code:: python
 

--- a/docs/task_on_kart.rst
+++ b/docs/task_on_kart.rst
@@ -147,6 +147,15 @@ The `load` method loads individual task input by passing a key of an input dicti
         data_b = self.load('b')
 
 
+As an alternative, the `load` method loads individual task input by passing an instance of TaskOnKart as follows:
+
+.. code:: python
+
+    def run(self):
+        data_a = self.load(TaskA())
+        data_b = self.load(TaskB())
+
+
 We can also omit the :func:`~gokart.task.TaskOnKart.requires` and write the task used by :func:`~gokart.parameter.TaskInstanceParameter`.
 Extensions include :func:`~gokart.task.TaskOnKart.load_data_frame` and :func:`~gokart.task.TaskOnKart.load_generator`. Please refer to :func:`~gokart.task.TaskOnKart.load`, :doc:`task_parameters`, and described later Advanced Features section.
 

--- a/docs/task_parameters.rst
+++ b/docs/task_parameters.rst
@@ -21,7 +21,7 @@ Please refer to `luigi document <https://luigi.readthedocs.io/en/stable/api/luig
 Gokart Parameter
 ================
 
-There are also parameters provided by gokart. 
+There are also parameters provided by gokart.
 
 - gokart.TaskInstanceParameter
 - gokart.ListTaskInstanceParameter
@@ -36,12 +36,12 @@ The :func:`~gokart.parameter.TaskInstanceParameter` executes a task using the re
 
 .. code:: python
 
-    class TaskA(gokart.TaskOnKart):
+    class TaskA(gokart.TaskOnKart[str]):
         def run(self):
             self.dump('Hello')
 
 
-    class TaskB(gokart.TaskOnKart):
+    class TaskB(gokart.TaskOnKart[str]):
         require_task = gokart.TaskInstanceParameter()
 
         def requires(self):

--- a/docs/task_settings.rst
+++ b/docs/task_settings.rst
@@ -59,7 +59,7 @@ When used from an argument as follows:
 .. code:: python
 
     # main.py
-    class Task(gokart.TaskOnKart):
+    class Task(gokart.TaskOnKart[str]):
         def run(self):
             self.dump('hello')
 
@@ -101,7 +101,7 @@ Every task has a parameter named :attr:`~gokart.task.TaskOnKart.fix_random_seed_
     import numpy
     import torch
 
-    class Task(gokart.TaskOnKart):
+    class Task(gokart.TaskOnKart[dict[str, Any]]):
         def run(self):
             x = [random.randint(0, 100) for _ in range(0, 10)]
             y = [np.random.randint(0, 100) for _ in range(0, 10)]

--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -85,5 +85,5 @@ class ExplicitBoolParameter(luigi.BoolParameter):
     def __init__(self, *args, **kwargs):
         luigi.Parameter.__init__(self, *args, **kwargs)
 
-    def _parser_kwargs(self, *args, **kwargs):
+    def _parser_kwargs(self, *args, **kwargs):  # type: ignore
         return luigi.Parameter._parser_kwargs(*args, *kwargs)

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -385,6 +385,8 @@ class TaskOnKart(luigi.Task, Generic[T]):
             result: FlattenableItems[TargetOnKart] = input[target]
             return result
         if isinstance(target, TaskOnKart):
+            requires_unique_ids = [task.make_unique_id() for task in flatten(self.requires())]
+            assert target.make_unique_id() in requires_unique_ids, f'{target} should be in requires method'
             return target.output()
         return target
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -923,12 +923,12 @@ files = [
 
 [[package]]
 name = "luigi"
-version = "3.5.1"
+version = "3.5.2"
 description = "Workflow mgmgt + task scheduling + dependency resolution."
 optional = false
 python-versions = "*"
 files = [
-    {file = "luigi-3.5.1.tar.gz", hash = "sha256:fc790b2747515dd19c673efbb8e4c9ace5f4c5cdc31f8e7f93dc667deb2ec6c8"},
+    {file = "luigi-3.5.2.tar.gz", hash = "sha256:d000fe6a6ea77c9376674fe87a045ac00c3fcf7ebe8414655a06630aa9db5111"},
 ]
 
 [package.dependencies]
@@ -1200,38 +1200,38 @@ xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
 name = "mypy"
-version = "1.11.0"
+version = "1.11.2"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a3824187c99b893f90c845bab405a585d1ced4ff55421fdf5c84cb7710995229"},
-    {file = "mypy-1.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:96f8dbc2c85046c81bcddc246232d500ad729cb720da4e20fce3b542cab91287"},
-    {file = "mypy-1.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a5d8d8dd8613a3e2be3eae829ee891b6b2de6302f24766ff06cb2875f5be9c6"},
-    {file = "mypy-1.11.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:72596a79bbfb195fd41405cffa18210af3811beb91ff946dbcb7368240eed6be"},
-    {file = "mypy-1.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:35ce88b8ed3a759634cb4eb646d002c4cef0a38f20565ee82b5023558eb90c00"},
-    {file = "mypy-1.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:98790025861cb2c3db8c2f5ad10fc8c336ed2a55f4daf1b8b3f877826b6ff2eb"},
-    {file = "mypy-1.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:25bcfa75b9b5a5f8d67147a54ea97ed63a653995a82798221cca2a315c0238c1"},
-    {file = "mypy-1.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bea2a0e71c2a375c9fa0ede3d98324214d67b3cbbfcbd55ac8f750f85a414e3"},
-    {file = "mypy-1.11.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2b3d36baac48e40e3064d2901f2fbd2a2d6880ec6ce6358825c85031d7c0d4d"},
-    {file = "mypy-1.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:d8e2e43977f0e09f149ea69fd0556623919f816764e26d74da0c8a7b48f3e18a"},
-    {file = "mypy-1.11.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1d44c1e44a8be986b54b09f15f2c1a66368eb43861b4e82573026e04c48a9e20"},
-    {file = "mypy-1.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cea3d0fb69637944dd321f41bc896e11d0fb0b0aa531d887a6da70f6e7473aba"},
-    {file = "mypy-1.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a83ec98ae12d51c252be61521aa5731f5512231d0b738b4cb2498344f0b840cd"},
-    {file = "mypy-1.11.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c7b73a856522417beb78e0fb6d33ef89474e7a622db2653bc1285af36e2e3e3d"},
-    {file = "mypy-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:f2268d9fcd9686b61ab64f077be7ffbc6fbcdfb4103e5dd0cc5eaab53a8886c2"},
-    {file = "mypy-1.11.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:940bfff7283c267ae6522ef926a7887305945f716a7704d3344d6d07f02df850"},
-    {file = "mypy-1.11.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:14f9294528b5f5cf96c721f231c9f5b2733164e02c1c018ed1a0eff8a18005ac"},
-    {file = "mypy-1.11.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7b54c27783991399046837df5c7c9d325d921394757d09dbcbf96aee4649fe9"},
-    {file = "mypy-1.11.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:65f190a6349dec29c8d1a1cd4aa71284177aee5949e0502e6379b42873eddbe7"},
-    {file = "mypy-1.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:dbe286303241fea8c2ea5466f6e0e6a046a135a7e7609167b07fd4e7baf151bf"},
-    {file = "mypy-1.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:104e9c1620c2675420abd1f6c44bab7dd33cc85aea751c985006e83dcd001095"},
-    {file = "mypy-1.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f006e955718ecd8d159cee9932b64fba8f86ee6f7728ca3ac66c3a54b0062abe"},
-    {file = "mypy-1.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:becc9111ca572b04e7e77131bc708480cc88a911adf3d0239f974c034b78085c"},
-    {file = "mypy-1.11.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6801319fe76c3f3a3833f2b5af7bd2c17bb93c00026a2a1b924e6762f5b19e13"},
-    {file = "mypy-1.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:c1a184c64521dc549324ec6ef7cbaa6b351912be9cb5edb803c2808a0d7e85ac"},
-    {file = "mypy-1.11.0-py3-none-any.whl", hash = "sha256:56913ec8c7638b0091ef4da6fcc9136896914a9d60d54670a75880c3e5b99ace"},
-    {file = "mypy-1.11.0.tar.gz", hash = "sha256:93743608c7348772fdc717af4aeee1997293a1ad04bc0ea6efa15bf65385c538"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef"},
+    {file = "mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383"},
+    {file = "mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8"},
+    {file = "mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca"},
+    {file = "mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104"},
+    {file = "mypy-1.11.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4"},
+    {file = "mypy-1.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36"},
+    {file = "mypy-1.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987"},
+    {file = "mypy-1.11.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca"},
+    {file = "mypy-1.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86"},
+    {file = "mypy-1.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce"},
+    {file = "mypy-1.11.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1"},
+    {file = "mypy-1.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70"},
+    {file = "mypy-1.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"},
+    {file = "mypy-1.11.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d"},
+    {file = "mypy-1.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24"},
+    {file = "mypy-1.11.2-py3-none-any.whl", hash = "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12"},
+    {file = "mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79"},
 ]
 
 [package.dependencies]

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -57,6 +57,17 @@ class _ParallelRunner(gokart.TaskOnKart[str]):
         self.dump('done')
 
 
+class _LoadRequires(gokart.TaskOnKart[str]):
+    task: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
+
+    def requires(self):
+        return self.task
+
+    def run(self):
+        s = self.load(self.task)
+        self.dump(s)
+
+
 class RunTest(unittest.TestCase):
     def setUp(self):
         luigi.setup_logging.DaemonLogging._configured = False
@@ -101,6 +112,11 @@ class RunTest(unittest.TestCase):
     def test_failed_task(self):
         with self.assertRaises(GokartBuildError):
             gokart.build(_DummyFailedTask(), reset_register=False, log_level=logging.CRITICAL)
+
+    def test_load_requires(self):
+        text = 'test'
+        output = gokart.build(_LoadRequires(task=_DummyTask(param=text)), reset_register=False)
+        self.assertEqual(output, text)
 
 
 class LoggerConfigTest(unittest.TestCase):

--- a/test/test_explicit_bool_parameter.py
+++ b/test/test_explicit_bool_parameter.py
@@ -24,7 +24,7 @@ class ExplicitParsing(gokart.TaskOnKart):
     param = gokart.ExplicitBoolParameter()
 
     def run(self):
-        ExplicitParsing._param = self.param
+        ExplicitParsing._param = self.param  # type: ignore
 
 
 class TestExplicitBoolParameter(unittest.TestCase):

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -311,12 +311,30 @@ class TaskTest(unittest.TestCase):
         task = _DummyTask()
 
         task2 = MagicMock(spec=gokart.TaskOnKart)
+        task2.make_unique_id.return_value = 'task2'
         task2_output = MagicMock(spec=TargetOnKart)
         task2.output.return_value = task2_output
         task2_output.load.return_value = 1
 
+        # task2 should be in requires' return values
+        task.requires = lambda: {'task2': task2}  # type: ignore
+
         actual = task.load(task2)
         self.assertEqual(actual, 1)
+
+    def test_load_with_task_on_kart_should_fail_when_task_on_kart_is_not_in_requires(self):
+        """
+        if load args is not in requires, it should raise an error.
+        """
+        task = _DummyTask()
+
+        task2 = MagicMock(spec=gokart.TaskOnKart)
+        task2_output = MagicMock(spec=TargetOnKart)
+        task2.output.return_value = task2_output
+        task2_output.load.return_value = 1
+
+        with self.assertRaises(AssertionError):
+            task.load(task2)
 
     def test_load_generator_with_single_target(self):
         task = _DummyTask()

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -3,7 +3,7 @@ import pathlib
 import unittest
 from datetime import datetime
 from typing import Any, Dict, List, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, patch
 
 import luigi
 import pandas as pd
@@ -95,12 +95,12 @@ class TaskTest(unittest.TestCase):
         self.assertTrue(task.complete(), msg='"rerun" flag should be changed.')
 
     def test_complete_with_uncompleted_input(self):
-        uncompleted_target = MagicMock(spec=TargetOnKart)
+        uncompleted_target = Mock(spec=TargetOnKart)
         uncompleted_target.exists.return_value = False
 
         # depends on an uncompleted target.
         task = _DummyTask()
-        task.input = MagicMock(return_value=uncompleted_target)  # type: ignore
+        task.input = Mock(return_value=uncompleted_target)  # type: ignore
         self.assertTrue(task.complete(), msg='task does not care input targets.')
 
         # make a task check its inputs.
@@ -108,18 +108,18 @@ class TaskTest(unittest.TestCase):
         self.assertFalse(task.complete())
 
     def test_complete_with_modified_input(self):
-        input_target = MagicMock(spec=TargetOnKart)
+        input_target = Mock(spec=TargetOnKart)
         input_target.exists.return_value = True
         input_target.last_modification_time.return_value = datetime(2018, 1, 1, 10, 0, 0)
-        output_target = MagicMock(spec=TargetOnKart)
+        output_target = Mock(spec=TargetOnKart)
         output_target.exists.return_value = True
         output_target.last_modification_time.return_value = datetime(2018, 1, 1, 9, 0, 0)
 
         # depends on an uncompleted target.
         task = _DummyTask()
         task.modification_time_check = False
-        task.input = MagicMock(return_value=input_target)  # type: ignore
-        task.output = MagicMock(return_value=output_target)  # type: ignore
+        task.input = Mock(return_value=input_target)  # type: ignore
+        task.output = Mock(return_value=output_target)  # type: ignore
         self.assertTrue(task.complete(), msg='task does not care modified time')
 
         # make a task check its inputs.
@@ -130,43 +130,43 @@ class TaskTest(unittest.TestCase):
         """Test the case that modification time of input equals that of output.
         The case is occurred when input and output targets are same.
         """
-        input_target = MagicMock(spec=TargetOnKart)
+        input_target = Mock(spec=TargetOnKart)
         input_target.exists.return_value = True
         input_target.last_modification_time.return_value = datetime(2018, 1, 1, 10, 0, 0)
-        output_target = MagicMock(spec=TargetOnKart)
+        output_target = Mock(spec=TargetOnKart)
         output_target.exists.return_value = True
         output_target.last_modification_time.return_value = datetime(2018, 1, 1, 10, 0, 0)
 
         task = _DummyTask()
         task.modification_time_check = True
-        task.input = MagicMock(return_value=input_target)  # type: ignore
-        task.output = MagicMock(return_value=output_target)  # type: ignore
+        task.input = Mock(return_value=input_target)  # type: ignore
+        task.output = Mock(return_value=output_target)  # type: ignore
         self.assertTrue(task.complete())
 
     def test_complete_when_input_and_output_equal(self):
-        target1 = MagicMock(spec=TargetOnKart)
+        target1 = Mock(spec=TargetOnKart)
         target1.exists.return_value = True
         target1.path.return_value = 'path1.pkl'
         target1.last_modification_time.return_value = datetime(2018, 1, 1, 10, 0, 0)
 
-        target2 = MagicMock(spec=TargetOnKart)
+        target2 = Mock(spec=TargetOnKart)
         target2.exists.return_value = True
         target2.path.return_value = 'path2.pkl'
         target2.last_modification_time.return_value = datetime(2018, 1, 1, 9, 0, 0)
 
-        target3 = MagicMock(spec=TargetOnKart)
+        target3 = Mock(spec=TargetOnKart)
         target3.exists.return_value = True
         target3.path.return_value = 'path3.pkl'
         target3.last_modification_time.return_value = datetime(2018, 1, 1, 9, 0, 0)
 
         task = _DummyTask()
         task.modification_time_check = True
-        task.input = MagicMock(return_value=[target1, target2])  # type: ignore
-        task.output = MagicMock(return_value=[target1, target2])  # type: ignore
+        task.input = Mock(return_value=[target1, target2])  # type: ignore
+        task.output = Mock(return_value=[target1, target2])  # type: ignore
         self.assertTrue(task.complete())
 
-        task.input = MagicMock(return_value=[target1, target2])  # type: ignore
-        task.output = MagicMock(return_value=[target2, target3])  # type: ignore
+        task.input = Mock(return_value=[target1, target2])  # type: ignore
+        task.output = Mock(return_value=[target2, target3])  # type: ignore
         self.assertFalse(task.complete())
 
     def test_default_target(self):
@@ -246,14 +246,14 @@ class TaskTest(unittest.TestCase):
 
     def test_make_model_target(self):
         task = _DummyTask()
-        target = task.make_model_target('test.zip', save_function=MagicMock(), load_function=MagicMock())
+        target = task.make_model_target('test.zip', save_function=Mock(), load_function=Mock())
         self.assertIsInstance(target, ModelTarget)
 
     def test_load_with_single_target(self):
         task = _DummyTask()
-        target = MagicMock(spec=TargetOnKart)
+        target = Mock(spec=TargetOnKart)
         target.load.return_value = 1
-        task.input = MagicMock(return_value=target)  # type: ignore
+        task.input = Mock(return_value=target)  # type: ignore
 
         data = task.load()
         target.load.assert_called_once()
@@ -261,9 +261,9 @@ class TaskTest(unittest.TestCase):
 
     def test_load_with_single_dict_target(self):
         task = _DummyTask()
-        target = MagicMock(spec=TargetOnKart)
+        target = Mock(spec=TargetOnKart)
         target.load.return_value = 1
-        task.input = MagicMock(return_value={'target_key': target})  # type: ignore
+        task.input = Mock(return_value={'target_key': target})  # type: ignore
 
         data = task.load()
         target.load.assert_called_once()
@@ -271,9 +271,9 @@ class TaskTest(unittest.TestCase):
 
     def test_load_with_keyword(self):
         task = _DummyTask()
-        target = MagicMock(spec=TargetOnKart)
+        target = Mock(spec=TargetOnKart)
         target.load.return_value = 1
-        task.input = MagicMock(return_value={'target_key': target})  # type: ignore
+        task.input = Mock(return_value={'target_key': target})  # type: ignore
 
         data = task.load('target_key')
         target.load.assert_called_once()
@@ -281,11 +281,11 @@ class TaskTest(unittest.TestCase):
 
     def test_load_tuple(self):
         task = _DummyTask()
-        target1 = MagicMock(spec=TargetOnKart)
+        target1 = Mock(spec=TargetOnKart)
         target1.load.return_value = 1
-        target2 = MagicMock(spec=TargetOnKart)
+        target2 = Mock(spec=TargetOnKart)
         target2.load.return_value = 2
-        task.input = MagicMock(return_value=(target1, target2))  # type: ignore
+        task.input = Mock(return_value=(target1, target2))  # type: ignore
 
         data = task.load()
         target1.load.assert_called_once()
@@ -295,11 +295,11 @@ class TaskTest(unittest.TestCase):
 
     def test_load_dictionary_at_once(self):
         task = _DummyTask()
-        target1 = MagicMock(spec=TargetOnKart)
+        target1 = Mock(spec=TargetOnKart)
         target1.load.return_value = 1
-        target2 = MagicMock(spec=TargetOnKart)
+        target2 = Mock(spec=TargetOnKart)
         target2.load.return_value = 2
-        task.input = MagicMock(return_value={'target_key_1': target1, 'target_key_2': target2})  # type: ignore
+        task.input = Mock(return_value={'target_key_1': target1, 'target_key_2': target2})  # type: ignore
 
         data = task.load()
         target1.load.assert_called_once()
@@ -310,9 +310,9 @@ class TaskTest(unittest.TestCase):
     def test_load_with_task_on_kart(self):
         task = _DummyTask()
 
-        task2 = MagicMock(spec=gokart.TaskOnKart)
+        task2 = Mock(spec=gokart.TaskOnKart)
         task2.make_unique_id.return_value = 'task2'
-        task2_output = MagicMock(spec=TargetOnKart)
+        task2_output = Mock(spec=TargetOnKart)
         task2.output.return_value = task2_output
         task2_output.load.return_value = 1
 
@@ -328,8 +328,8 @@ class TaskTest(unittest.TestCase):
         """
         task = _DummyTask()
 
-        task2 = MagicMock(spec=gokart.TaskOnKart)
-        task2_output = MagicMock(spec=TargetOnKart)
+        task2 = Mock(spec=gokart.TaskOnKart)
+        task2_output = Mock(spec=TargetOnKart)
         task2.output.return_value = task2_output
         task2_output.load.return_value = 1
 
@@ -339,15 +339,15 @@ class TaskTest(unittest.TestCase):
     def test_load_with_task_on_kart_list(self):
         task = _DummyTask()
 
-        task2 = MagicMock(spec=gokart.TaskOnKart[int])
+        task2 = Mock(spec=gokart.TaskOnKart)
         task2.make_unique_id.return_value = 'task2'
-        task2_output = MagicMock(spec=TargetOnKart)
+        task2_output = Mock(spec=TargetOnKart)
         task2.output.return_value = task2_output
         task2_output.load.return_value = 1
 
-        task3 = MagicMock(spec=gokart.TaskOnKart[int])
+        task3 = Mock(spec=gokart.TaskOnKart)
         task3.make_unique_id.return_value = 'task3'
-        task3_output = MagicMock(spec=TargetOnKart)
+        task3_output = Mock(spec=TargetOnKart)
         task3.output.return_value = task3_output
         task3_output.load.return_value = 2
 
@@ -360,32 +360,32 @@ class TaskTest(unittest.TestCase):
 
     def test_load_generator_with_single_target(self):
         task = _DummyTask()
-        target = MagicMock(spec=TargetOnKart)
+        target = Mock(spec=TargetOnKart)
         target.load.return_value = [1, 2]
-        task.input = MagicMock(return_value=target)  # type: ignore
+        task.input = Mock(return_value=target)  # type: ignore
         data = [x for x in task.load_generator()]
         self.assertEqual(data, [[1, 2]])
 
     def test_load_generator_with_keyword(self):
         task = _DummyTask()
-        target = MagicMock(spec=TargetOnKart)
+        target = Mock(spec=TargetOnKart)
         target.load.return_value = [1, 2]
-        task.input = MagicMock(return_value={'target_key': target})  # type: ignore
+        task.input = Mock(return_value={'target_key': target})  # type: ignore
         data = [x for x in task.load_generator('target_key')]
         self.assertEqual(data, [[1, 2]])
 
     def test_load_generator_with_list_task_on_kart(self):
         task = _DummyTask()
 
-        task2 = MagicMock(spec=gokart.TaskOnKart)
+        task2 = Mock(spec=gokart.TaskOnKart)
         task2.make_unique_id.return_value = 'task2'
-        task2_output = MagicMock(spec=TargetOnKart)
+        task2_output = Mock(spec=TargetOnKart)
         task2.output.return_value = task2_output
         task2_output.load.return_value = 1
 
-        task3 = MagicMock(spec=gokart.TaskOnKart)
+        task3 = Mock(spec=gokart.TaskOnKart)
         task3.make_unique_id.return_value = 'task3'
-        task3_output = MagicMock(spec=TargetOnKart)
+        task3_output = Mock(spec=TargetOnKart)
         task3.output.return_value = task3_output
         task3_output.load.return_value = 2
 
@@ -398,8 +398,8 @@ class TaskTest(unittest.TestCase):
 
     def test_dump(self):
         task = _DummyTask()
-        target = MagicMock(spec=TargetOnKart)
-        task.output = MagicMock(return_value=target)  # type: ignore
+        target = Mock(spec=TargetOnKart)
+        task.output = Mock(return_value=target)  # type: ignore
 
         task.dump(1)  # type: ignore
         target.dump.assert_called_once()
@@ -407,8 +407,8 @@ class TaskTest(unittest.TestCase):
     def test_fail_on_empty_dump(self):
         # do not fail
         task = _DummyTask(fail_on_empty_dump=False)
-        target = MagicMock(spec=TargetOnKart)
-        task.output = MagicMock(return_value=target)  # type: ignore
+        target = Mock(spec=TargetOnKart)
+        task.output = Mock(return_value=target)  # type: ignore
         task.dump(pd.DataFrame())
         target.dump.assert_called_once()
 
@@ -417,7 +417,7 @@ class TaskTest(unittest.TestCase):
         self.assertRaises(AssertionError, lambda: task.dump(pd.DataFrame()))
 
     @patch('luigi.configuration.get_config')
-    def test_add_configuration(self, mock_config: MagicMock):
+    def test_add_configuration(self, mock_config: Mock):
         mock_config.return_value = {'_DummyTask': {'list_param': '["c", "d"]', 'param': '3', 'bool_param': 'True'}}
         kwargs: Dict[str, Any] = dict()
         _DummyTask._add_configuration(kwargs, '_DummyTask')
@@ -426,7 +426,7 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(True, kwargs['bool_param'])
 
     @patch('luigi.cmdline_parser.CmdlineParser.get_instance')
-    def test_add_cofigureation_evaluation_order(self, mock_cmdline: MagicMock):
+    def test_add_cofigureation_evaluation_order(self, mock_cmdline: Mock):
         """
         in case TaskOnKart._add_configuration will break evaluation order
         @see https://luigi.readthedocs.io/en/stable/parameters.html#parameter-resolution-order
@@ -444,7 +444,7 @@ class TaskTest(unittest.TestCase):
 
     def test_load_list_of_list_pandas(self):
         task = _DummyTask()
-        task.load = MagicMock(return_value=[pd.DataFrame(dict(a=[1])), [pd.DataFrame(dict(a=[2])), pd.DataFrame(dict(a=[3]))]])  # type: ignore
+        task.load = Mock(return_value=[pd.DataFrame(dict(a=[1])), [pd.DataFrame(dict(a=[2])), pd.DataFrame(dict(a=[3]))]])  # type: ignore
 
         df = task.load_data_frame()
         self.assertIsInstance(df, pd.DataFrame)
@@ -452,7 +452,7 @@ class TaskTest(unittest.TestCase):
 
     def test_load_single_value_dict_of_dataframe(self):
         task = _DummyTask()
-        task.load = MagicMock(return_value={'a': pd.DataFrame(dict(a=[1]))})  # type: ignore
+        task.load = Mock(return_value={'a': pd.DataFrame(dict(a=[1]))})  # type: ignore
 
         df = task.load_data_frame()
         self.assertIsInstance(df, pd.DataFrame)
@@ -460,7 +460,7 @@ class TaskTest(unittest.TestCase):
 
     def test_load_data_frame_drop_columns(self):
         task = _DummyTask()
-        task.load = MagicMock(return_value=pd.DataFrame(dict(a=[1], b=[2], c=[3])))  # type: ignore
+        task.load = Mock(return_value=pd.DataFrame(dict(a=[1], b=[2], c=[3])))  # type: ignore
 
         df = task.load_data_frame(required_columns={'a', 'c'}, drop_columns=True)
         self.assertIsInstance(df, pd.DataFrame)
@@ -469,7 +469,7 @@ class TaskTest(unittest.TestCase):
 
     def test_load_data_frame_empty_input(self):
         task = _DummyTask()
-        task.load = MagicMock(return_value=pd.DataFrame(dict(a=[], b=[], c=[])))  # type: ignore
+        task.load = Mock(return_value=pd.DataFrame(dict(a=[], b=[], c=[])))  # type: ignore
 
         df = task.load_data_frame(required_columns={'a', 'c'})
         self.assertIsInstance(df, pd.DataFrame)
@@ -478,7 +478,7 @@ class TaskTest(unittest.TestCase):
 
     def test_load_index_only_dataframe(self):
         task = _DummyTask()
-        task.load = MagicMock(return_value=pd.DataFrame(index=range(3)))  # type: ignore
+        task.load = Mock(return_value=pd.DataFrame(index=range(3)))  # type: ignore
 
         # connnot load index only frame with required_columns
         self.assertRaises(AssertionError, lambda: task.load_data_frame(required_columns={'a', 'c'}))
@@ -626,7 +626,7 @@ class _DummyTaskWithCompleted(gokart.TaskOnKart):
 class TestCompleteCheckAtRun(unittest.TestCase):
     def test_run_when_complete_check_at_run_is_false_and_task_is_not_completed(self):
         task = _DummyTaskWithNonCompleted(complete_check_at_run=False)
-        task.dump = MagicMock()  # type: ignore
+        task.dump = Mock()  # type: ignore
         task.run()
 
         # since run() is called, dump() should be called.
@@ -634,7 +634,7 @@ class TestCompleteCheckAtRun(unittest.TestCase):
 
     def test_run_when_complete_check_at_run_is_false_and_task_is_completed(self):
         task = _DummyTaskWithCompleted(complete_check_at_run=False)
-        task.dump = MagicMock()  # type: ignore
+        task.dump = Mock()  # type: ignore
         task.run()
 
         # even task is completed, since run() is called, dump() should be called.
@@ -642,7 +642,7 @@ class TestCompleteCheckAtRun(unittest.TestCase):
 
     def test_run_when_complete_check_at_run_is_true_and_task_is_not_completed(self):
         task = _DummyTaskWithNonCompleted(complete_check_at_run=True)
-        task.dump = MagicMock()  # type: ignore
+        task.dump = Mock()  # type: ignore
         task.run()
 
         # since task is not completed, when run() is called, dump() should be called.
@@ -650,7 +650,7 @@ class TestCompleteCheckAtRun(unittest.TestCase):
 
     def test_run_when_complete_check_at_run_is_true_and_task_is_completed(self):
         task = _DummyTaskWithCompleted(complete_check_at_run=True)
-        task.dump = MagicMock()  # type: ignore
+        task.dump = Mock()  # type: ignore
         task.run()
 
         # since task is completed, even when run() is called, dump() should not be called.

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -305,6 +305,17 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(data['target_key_1'], 1)
         self.assertEqual(data['target_key_2'], 2)
 
+    def test_load_with_task_on_kart(self):
+        task = _DummyTask()
+
+        task2 = MagicMock(spec=gokart.TaskOnKart)
+        task2_output = MagicMock(spec=TargetOnKart)
+        task2.output.return_value = task2_output
+        task2_output.load.return_value = 1
+
+        actual = task.load(task2)
+        self.assertEqual(actual, 1)
+
     def test_load_generator_with_single_target(self):
         task = _DummyTask()
         target = MagicMock(spec=TargetOnKart)


### PR DESCRIPTION
Add load type for TaskOnKart.

```python
class SampleTask(gokart.TaskOnKart):
    str_task: gokart.TaskOnKart[str] = gokart.TaskInstanceParameter()
    int_task: gokart.TaskOnKart[int] = gokart.TaskInstanceParameter()

    def requires(self):
        return dict(str=self.str_task, int=self.int_task)

    def run(self):
        s = self.load(self.str_task)  # This type is inferred with "str"
        i = self.load(self.int_task)  # This type is inferred with "int"

SampleTask(
    str_task=StrTask(),  # mypy ok
    int_task=StrTask(),  # mypy error: Argument "int_task" to "StrTask" has incompatible type "StrTask"; expected "TaskOnKart[int]
)
```

TODO

- [x] should check TaskOnKart which is arguments of load method is in `requires` results
- [x] write docs