### PR TITLE
fix is_parameter_call

### DIFF
--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -10,6 +10,7 @@ class TestMyMypyPlugin(unittest.TestCase):
     def test_plugin_no_issue(self):
         test_code = """
 import luigi
+from luigi import Parameter
 import gokart
 
 
@@ -18,11 +19,12 @@ class MyTask(gokart.TaskOnKart):
     foo: int = luigi.IntParameter() # type: ignore
     bar: str = luigi.Parameter() # type: ignore
     baz: bool = gokart.ExplicitBoolParameter()
+    qux: str = Parameter()
 
 
 # TaskOnKart parameters:
 #   - `complete_check_at_run`
-MyTask(foo=1, bar='bar', baz=False, complete_check_at_run=False)
+MyTask(foo=1, bar='bar', baz=False, qux='qux', complete_check_at_run=False)
 """
 
         with tempfile.NamedTemporaryFile(suffix='.py') as test_file:


### PR DESCRIPTION
Currently, luigi doesn't provide py.typed. it will be released next to 3.5.1.

https://github.com/spotify/luigi/pull/3297

With the following code, we can't assume type correctly.

```python                                                                      
from luigi import Parameter

class MyTask(gokart.TaskOnKart):
    param = Parameter()
```