### PR TITLE
fix: handle default type for `DateMinuteParameter`

### DIFF
--- a/gokart/mypy.py
+++ b/gokart/mypy.py
@@ -97,8 +97,13 @@ class TaskOnKartPlugin(Plugin):
           foo: int = luigi.IntParameter()
           ```
         """
+        try:
+            default_idx = ctx.callee_arg_names.index('default')
+        # if no `default` argument is found, return AnyType with unannotated type.
+        except ValueError:
+            return AnyType(TypeOfAny.unannotated)
 
-        default_args = ctx.args[0]
+        default_args = ctx.args[default_idx]
 
         if default_args:
             default_type = ctx.arg_types[0][0]

--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -12,6 +12,7 @@ class TestMyMypyPlugin(unittest.TestCase):
 import luigi
 from luigi import Parameter
 import gokart
+import datetime
 
 
 class MyTask(gokart.TaskOnKart):
@@ -20,6 +21,9 @@ class MyTask(gokart.TaskOnKart):
     bar: str = luigi.Parameter() # type: ignore
     baz: bool = gokart.ExplicitBoolParameter()
     qux: str = Parameter()
+    # https://github.com/m3dev/gokart/issues/395
+    datetime: datetime.datetime = luigi.DateMinuteParameter(interval=10, default=datetime.datetime(2021, 1, 1))
+
 
 
 # TaskOnKart parameters:


### PR DESCRIPTION
## What
* fixes #395
* before this PR, `default` argument is assumed to be positioned on the first argument
  * but some paramters like `DateMinuteParmeter` not
* This PR aims to find the position of `default` argument by the keyword name

