### PR TITLE
Breaking change: Don't extract value from 1-length dict

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -291,8 +291,6 @@ class TaskOnKart(luigi.Task, Generic[T]):
             return targets.load()
 
         data = _load(self._get_input_targets(target))
-        if target is None and isinstance(data, dict) and len(data) == 1:
-            return list(data.values())[0]
         return data
 
     @overload

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -290,8 +290,7 @@ class TaskOnKart(luigi.Task, Generic[T]):
                 return {k: _load(t) for k, t in targets.items()}
             return targets.load()
 
-        data = _load(self._get_input_targets(target))
-        return data
+        return _load(self._get_input_targets(target))
 
     @overload
     def load_generator(self, target: Union[None, str, TargetOnKart] = None) -> Generator[Any, None, None]: ...

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -267,7 +267,7 @@ class TaskTest(unittest.TestCase):
 
         data = task.load()
         target.load.assert_called_once()
-        self.assertEqual(data, 1)
+        self.assertEqual(data, {'target_key': 1})
 
     def test_load_with_keyword(self):
         task = _DummyTask()


### PR DESCRIPTION
FIX: https://github.com/m3dev/gokart/issues/293

As mentioned in above issue, when loading 1-length dictionary with `self.load()` (no target specified), the value of dict will be loaded instead of dictionary itself.

Although this feature allows shorthand as described in the issue, the benefit is very limited and disadvantage caused by confusion is more significant.

Therefore, I want to delete this implementation.

----

This PR will cause following change.

```
class A(gokart.TaskOnKart):
    task_a = gokart.TaskInstanceParameter()

    def run(self):
        a = self.load()
        # From this PR, `a` will become a dictionary, instead of value of output of task_a
        # so, if you want to extract the value, you must specify key name as
        # a = self.load('task_a')
```