### PR TITLE
feat: implement DI tools for gokart

### DIFF
--- a/gokart/__init__.py
+++ b/gokart/__init__.py
@@ -1,4 +1,5 @@
 from gokart.build import build  # noqa:F401
+from gokart.dependencies import Depends  # noqa:F401
 from gokart.info import make_tree_info, tree_info  # noqa:F401
 from gokart.pandas_type_config import PandasTypeConfig  # noqa:F401
 from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, TaskInstanceParameter  # noqa:F401

--- a/gokart/dependencies.py
+++ b/gokart/dependencies.py
@@ -1,0 +1,66 @@
+import inspect
+from functools import partial
+from typing import Any, Callable, Dict, Generic, TypeVar
+
+import luigi
+
+T = TypeVar('T')
+
+
+class Depends(Generic[T]):
+    def __init__(self, func: Callable[..., T]):
+        self._func = func
+
+
+def _resolve_dependencies(depends: Depends[T], kwargs: Dict[str, Any]) -> T:
+    depends_func_signature = inspect.signature(depends._func)
+    depends_func_params = depends_func_signature.parameters
+
+    params = {}
+    for param_name, param in depends_func_params.items():
+        default = param.default
+        annotation = param.annotation
+        if isinstance(default, Depends):
+            params[param_name] = _resolve_dependencies(default, kwargs)
+        elif default is inspect.Parameter.empty and param_name in kwargs:
+            params[param_name] = kwargs[param_name]
+        elif default is not inspect.Parameter.empty:
+            params[param_name] = default
+        # NOTE: support luigi.Config as parameter of dependency functions
+        elif issubclass(annotation, luigi.Config):
+            params[param_name] = annotation()
+        else:
+            raise ValueError(f'Parameter {param_name} cannot be resolved.')
+    return depends._func(**params)
+
+
+def resolve_run_dependencies_wrapper(run: Callable, param_kwargs: Dict[str, Any]) -> Callable:
+    """Resolve dependencies of `run` method of Task
+
+    Dependencies are resolved by the following rules:
+
+    * If the parameter has a default value, the default value is used.
+    * If the parameter has a default value of Depends, the dependency is resolved recursively.
+    * If the parameter name is defined in task parameters, the value is used.
+    * If the parameter type is luigi.Config, the instance of the config is created and used.
+
+    Args:
+        run (Callable): callback to be wrapped
+        param_kwargs (Dict[str, Any]): parameters of the task
+
+    Returns:
+        run (Callable): wrapped callback with dependencies resolved
+    """
+    run_signature = inspect.signature(run)
+    params = run_signature.parameters
+
+    dependencies: Dict[str, Any] = {}
+    for param_name, param in params.items():
+        default = param.default
+        if default is inspect.Parameter.empty:
+            raise ValueError(f'All parameters of `run` method must have Depends default. {param_name} has no default.')
+        if not isinstance(default, Depends):
+            raise ValueError(f'Only Depends is allowed `run` method parameter. {param_name} is not Depends.')
+        dependencies[param_name] = _resolve_dependencies(default, param_kwargs)
+
+    return partial(run, **dependencies)

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -15,6 +15,7 @@ import gokart
 import gokart.target
 from gokart.conflict_prevention_lock.task_lock import make_task_lock_params, make_task_lock_params_for_run
 from gokart.conflict_prevention_lock.task_lock_wrappers import wrap_run_with_lock
+from gokart.dependencies import resolve_run_dependencies_wrapper
 from gokart.file_processor import FileProcessor
 from gokart.pandas_type_config import PandasTypeConfigMap
 from gokart.parameter import ExplicitBoolParameter, ListTaskInstanceParameter, TaskInstanceParameter
@@ -111,6 +112,7 @@ class TaskOnKart(luigi.Task, Generic[T]):
         super(TaskOnKart, self).__init__(*args, **kwargs)
         self._rerun_state = self.rerun
         self._lock_at_dump = True
+        self.run = resolve_run_dependencies_wrapper(self.run, self.param_kwargs)  # type: ignore
 
         if self.complete_check_at_run:
             self.run = task_complete_check_wrapper(run_func=self.run, complete_check_func=self.complete)  # type: ignore

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -112,7 +112,6 @@ class TaskOnKart(luigi.Task, Generic[T]):
         super(TaskOnKart, self).__init__(*args, **kwargs)
         self._rerun_state = self.rerun
         self._lock_at_dump = True
-        self.run = resolve_run_dependencies_wrapper(self.run, self.param_kwargs)  # type: ignore
 
         if self.complete_check_at_run:
             self.run = task_complete_check_wrapper(run_func=self.run, complete_check_func=self.complete)  # type: ignore
@@ -123,6 +122,8 @@ class TaskOnKart(luigi.Task, Generic[T]):
             assert self.redis_port is not None, 'redis_port must be set when should_lock_run is True.'
             task_lock_params = make_task_lock_params_for_run(task_self=self)
             self.run = wrap_run_with_lock(run_func=self.run, task_lock_params=task_lock_params)  # type: ignore
+
+        self.run = resolve_run_dependencies_wrapper(self.run, self.param_kwargs)  # type: ignore
 
     def input(self) -> FlattenableItems[TargetOnKart]:
         return super().input()

--- a/test/config/test_config.ini
+++ b/test/config/test_config.ini
@@ -3,3 +3,6 @@ param = ${test_param}
 
 [test_build._DummyTask]
 param = ${test_param}
+
+[FooConfig]
+name = foo

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -52,7 +52,6 @@ class _DummyFailedTask(gokart.TaskOnKart):
 class _ParallelRunner(gokart.TaskOnKart[str]):
     def requires(self):
         return [_DummyTask(param=str(i)) for i in range(10)]
-        # return [_DummyTask(param=str(i), complete_check_at_run=i % 2 == 0) for i in range(10)]
 
     def run(self):
         self.dump('done')

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -52,6 +52,7 @@ class _DummyFailedTask(gokart.TaskOnKart):
 class _ParallelRunner(gokart.TaskOnKart[str]):
     def requires(self):
         return [_DummyTask(param=str(i)) for i in range(10)]
+        # return [_DummyTask(param=str(i), complete_check_at_run=i % 2 == 0) for i in range(10)]
 
     def run(self):
         self.dump('done')

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,49 +1,49 @@
-# import luigi
+import luigi
 
-# import gokart
-# from test.config import TEST_CONFIG_INI
-
-
-# class FooConfig(luigi.Config):
-#     name: str = luigi.Parameter()
+import gokart
+from test.config import TEST_CONFIG_INI
 
 
-# class Foo:
-#     def __init__(self, name: str, version: str) -> None:
-#         self.name = name
-#         self.version = version
+class FooConfig(luigi.Config):
+    name: str = luigi.Parameter()
 
 
-# class Bar:
-#     def __init__(self, foo: Foo) -> None:
-#         self.foo = foo
+class Foo:
+    def __init__(self, name: str, version: str) -> None:
+        self.name = name
+        self.version = version
 
 
-# def build_foo(config: FooConfig, version: str) -> Foo:
-#     """`build_foo` function depends on `FooConfig` and `version` parameters.
-#     `version` parameter is passed from `DummyTask` in the resolving dependencies process.
-#     """
-#     return Foo(name=config.name, version=version)
+class Bar:
+    def __init__(self, foo: Foo) -> None:
+        self.foo = foo
 
 
-# def build_bar(foo: Foo = gokart.Depends(build_foo)) -> Bar:
-#     """NOTE: `build_bar` depends on the result of `build_foo` function."""
-#     return Bar(foo=foo)
+def build_foo(config: FooConfig, version: str) -> Foo:
+    """`build_foo` function depends on `FooConfig` and `version` parameters.
+    `version` parameter is passed from `DummyTask` in the resolving dependencies process.
+    """
+    return Foo(name=config.name, version=version)
 
 
-# class DummyTask(gokart.TaskOnKart[None]):
-#     task_namespace = __name__
-#     version: str = luigi.Parameter()
-
-#     def run(self, foo: Foo = gokart.Depends(build_foo), bar: Bar = gokart.Depends(build_bar)):
-#         assert isinstance(foo, Foo)
-#         assert isinstance(bar, Bar)
-#         assert foo.name == 'foo'
-#         assert foo.version == self.version
-#         assert bar.foo.name == 'foo'
-#         self.dump(None)
+def build_bar(foo: Foo = gokart.Depends(build_foo)) -> Bar:
+    """NOTE: `build_bar` depends on the result of `build_foo` function."""
+    return Bar(foo=foo)
 
 
-# def test_success():
-#     gokart.utils.add_config(str(TEST_CONFIG_INI))
-#     gokart.build(DummyTask(version='1.0.0'))
+class DummyTask(gokart.TaskOnKart[None]):
+    task_namespace = "aaaaaaaaa"
+    version: str = luigi.Parameter()
+
+    def run(self, foo: Foo = gokart.Depends(build_foo), bar: Bar = gokart.Depends(build_bar)):
+        assert isinstance(foo, Foo)
+        assert isinstance(bar, Bar)
+        assert foo.name == 'foo'
+        assert foo.version == self.version
+        assert bar.foo.name == 'foo'
+        self.dump(None)
+
+
+def test_success():
+    gokart.utils.add_config(str(TEST_CONFIG_INI))
+    gokart.build(DummyTask(version='1.0.0'))

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,0 +1,48 @@
+import luigi
+
+import gokart
+from test.config import TEST_CONFIG_INI
+
+
+class FooConfig(luigi.Config):
+    name: str = luigi.Parameter()
+
+
+class Foo:
+    def __init__(self, name: str, version: str) -> None:
+        self.name = name
+        self.version = version
+
+
+class Bar:
+    def __init__(self, foo: Foo) -> None:
+        self.foo = foo
+
+
+def build_foo(config: FooConfig, version: str) -> Foo:
+    """`build_foo` function depends on `FooConfig` and `version` parameters.
+    `version` parameter is passed from `DummyTask` in the resolving dependencies process.
+    """
+    return Foo(name=config.name, version=version)
+
+
+def build_bar(foo: Foo = gokart.Depends(build_foo)) -> Bar:
+    """NOTE: `build_bar` depends on the result of `build_foo` function."""
+    return Bar(foo=foo)
+
+
+class DummyTask(gokart.TaskOnKart[None]):
+    version: str = luigi.Parameter()
+
+    def run(self, foo: Foo = gokart.Depends(build_foo), bar: Bar = gokart.Depends(build_bar)):
+        assert isinstance(foo, Foo)
+        assert isinstance(bar, Bar)
+        assert foo.name == 'foo'
+        assert foo.version == self.version
+        assert bar.foo.name == 'foo'
+        self.dump(None)
+
+
+def test_success():
+    gokart.utils.add_config(str(TEST_CONFIG_INI))
+    gokart.build(DummyTask(version='1.0.0'))

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -32,6 +32,7 @@ def build_bar(foo: Foo = gokart.Depends(build_foo)) -> Bar:
 
 
 class DummyTask(gokart.TaskOnKart[None]):
+    task_namespace = __name__
     version: str = luigi.Parameter()
 
     def run(self, foo: Foo = gokart.Depends(build_foo), bar: Bar = gokart.Depends(build_bar)):

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,49 +1,49 @@
-import luigi
+# import luigi
 
-import gokart
-from test.config import TEST_CONFIG_INI
-
-
-class FooConfig(luigi.Config):
-    name: str = luigi.Parameter()
+# import gokart
+# from test.config import TEST_CONFIG_INI
 
 
-class Foo:
-    def __init__(self, name: str, version: str) -> None:
-        self.name = name
-        self.version = version
+# class FooConfig(luigi.Config):
+#     name: str = luigi.Parameter()
 
 
-class Bar:
-    def __init__(self, foo: Foo) -> None:
-        self.foo = foo
+# class Foo:
+#     def __init__(self, name: str, version: str) -> None:
+#         self.name = name
+#         self.version = version
 
 
-def build_foo(config: FooConfig, version: str) -> Foo:
-    """`build_foo` function depends on `FooConfig` and `version` parameters.
-    `version` parameter is passed from `DummyTask` in the resolving dependencies process.
-    """
-    return Foo(name=config.name, version=version)
+# class Bar:
+#     def __init__(self, foo: Foo) -> None:
+#         self.foo = foo
 
 
-def build_bar(foo: Foo = gokart.Depends(build_foo)) -> Bar:
-    """NOTE: `build_bar` depends on the result of `build_foo` function."""
-    return Bar(foo=foo)
+# def build_foo(config: FooConfig, version: str) -> Foo:
+#     """`build_foo` function depends on `FooConfig` and `version` parameters.
+#     `version` parameter is passed from `DummyTask` in the resolving dependencies process.
+#     """
+#     return Foo(name=config.name, version=version)
 
 
-class DummyTask(gokart.TaskOnKart[None]):
-    task_namespace = __name__
-    version: str = luigi.Parameter()
-
-    def run(self, foo: Foo = gokart.Depends(build_foo), bar: Bar = gokart.Depends(build_bar)):
-        assert isinstance(foo, Foo)
-        assert isinstance(bar, Bar)
-        assert foo.name == 'foo'
-        assert foo.version == self.version
-        assert bar.foo.name == 'foo'
-        self.dump(None)
+# def build_bar(foo: Foo = gokart.Depends(build_foo)) -> Bar:
+#     """NOTE: `build_bar` depends on the result of `build_foo` function."""
+#     return Bar(foo=foo)
 
 
-def test_success():
-    gokart.utils.add_config(str(TEST_CONFIG_INI))
-    gokart.build(DummyTask(version='1.0.0'))
+# class DummyTask(gokart.TaskOnKart[None]):
+#     task_namespace = __name__
+#     version: str = luigi.Parameter()
+
+#     def run(self, foo: Foo = gokart.Depends(build_foo), bar: Bar = gokart.Depends(build_bar)):
+#         assert isinstance(foo, Foo)
+#         assert isinstance(bar, Bar)
+#         assert foo.name == 'foo'
+#         assert foo.version == self.version
+#         assert bar.foo.name == 'foo'
+#         self.dump(None)
+
+
+# def test_success():
+#     gokart.utils.add_config(str(TEST_CONFIG_INI))
+#     gokart.build(DummyTask(version='1.0.0'))


### PR DESCRIPTION
## Background

Tasks sometimes uses another class like API clients in the `run`.
`gokart.TaskOnKart` requires to create an instance in its task, because the parameters can only be injected.

Currently, we must write the following codes to do so.

### Overwrite constructor

```python
class Foo(gokart.TaskOnKart):
    name = luigi.Parameter()

    def __init__(*args, **kwargs):
        self._client = Client(...)
        super(Foo, self).__init__(*args, **kwargs)

    def run(self):
        self._client.foo()
```

### Create Instance in run

```python
class Foo(gokart.TaskOnKart):
    name = luigi.Parameter()

    def run(self):
        client = Client(name=self.foo)
        client.foo()
```

It seems to be noisy for me.

## This PR aims...

Introduce a DI system inspired by [FastAPI Depends](https://fastapi.tiangolo.com/ja/reference/dependencies/?h=de#fastapi.Depends).
The following is an example of this feature.

```python
def build_client(name: str) -> Client # name is resolved by task parameter
    return Client(name=name)


class Foo(gokart.TaskOnKart):
    name = luigi.Parameter()

    def run(self, client: Client= gokart.Depends(build_client)):
        client.foo()
```

Please also check the test codes which shows the example of resolving dependencies in recursive manner.
Let me know your frank opinion for this feature.


