### PR TITLE
feat: make worker skip running task when it is completed

### DIFF
--- a/gokart/worker.py
+++ b/gokart/worker.py
@@ -308,6 +308,63 @@ class ContextManagedTaskProcess(TaskProcess):
             super(ContextManagedTaskProcess, self).run()
 
 
+class gokart_worker(luigi.Config):
+    """Configuration for the gokart worker.
+
+    You can set these options of section [gokart_worker] in your luigi.cfg file.
+
+    NOTE: use snake_case for this class to match the luigi.Config convention.
+    """
+
+    id = luigi.Parameter(default='', description='Override the auto-generated worker_id')
+    ping_interval = luigi.FloatParameter(default=1.0, config_path=dict(section='core', name='worker-ping-interval'))
+    keep_alive = luigi.BoolParameter(default=False, config_path=dict(section='core', name='worker-keep-alive'))
+    count_uniques = luigi.BoolParameter(
+        default=False,
+        config_path=dict(section='core', name='worker-count-uniques'),
+        description='worker-count-uniques means that we will keep a ' 'worker alive only if it has a unique pending task, as ' 'well as having keep-alive true',
+    )
+    count_last_scheduled = luigi.BoolParameter(
+        default=False, description='Keep a worker alive only if there are ' 'pending tasks which it was the last to ' 'schedule.'
+    )
+    wait_interval = luigi.FloatParameter(default=1.0, config_path=dict(section='core', name='worker-wait-interval'))
+    wait_jitter = luigi.FloatParameter(default=5.0)
+
+    max_keep_alive_idle_duration = luigi.TimeDeltaParameter(default=datetime.timedelta(0))
+
+    max_reschedules = luigi.IntParameter(default=1, config_path=dict(section='core', name='worker-max-reschedules'))
+    timeout = luigi.IntParameter(default=0, config_path=dict(section='core', name='worker-timeout'))
+    task_limit = luigi.IntParameter(default=None, config_path=dict(section='core', name='worker-task-limit'))
+    retry_external_tasks = luigi.BoolParameter(
+        default=False,
+        config_path=dict(section='core', name='retry-external-tasks'),
+        description='If true, incomplete external tasks will be ' 'retested for completion while Luigi is running.',
+    )
+    send_failure_email = luigi.BoolParameter(default=True, description='If true, send e-mails directly from the worker' 'on failure')
+    no_install_shutdown_handler = luigi.BoolParameter(default=False, description='If true, the SIGUSR1 shutdown handler will' 'NOT be install on the worker')
+    check_unfulfilled_deps = luigi.BoolParameter(default=True, description='If true, check for completeness of ' 'dependencies before running a task')
+    check_complete_on_run = luigi.BoolParameter(
+        default=False,
+        description='If true, only mark tasks as done after running if they are complete. '
+        'Regardless of this setting, the worker will always check if external '
+        'tasks are complete before marking them as done.',
+    )
+    force_multiprocessing = luigi.BoolParameter(default=False, description='If true, use multiprocessing also when ' 'running with 1 worker')
+    task_process_context = luigi.OptionalParameter(
+        default=None,
+        description='If set to a fully qualified class name, the class will '
+        'be instantiated with a TaskProcess as its constructor parameter and '
+        'applied as a context manager around its run() call, so this can be '
+        'used for obtaining high level customizable monitoring or logging of '
+        'each individual Task run.',
+    )
+    cache_task_completion = luigi.BoolParameter(
+        default=False,
+        description='If true, cache the response of successful completion checks '
+        'of tasks assigned to a worker. This can especially speed up tasks with '
+        'dynamic dependencies but assumes that the completion status does not change '
+        'after it was true the first time.',
+    )
 class Worker:
     """
     Worker object communicates with a scheduler.

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -2,11 +2,12 @@ import uuid
 from unittest.mock import Mock
 
 import luigi
+import luigi.worker
 import pytest
 from luigi import scheduler
 
 import gokart
-from gokart.worker import Worker
+from gokart.worker import Worker, gokart_worker
 
 
 class _DummyTask(gokart.TaskOnKart):
@@ -33,3 +34,49 @@ class TestWorkerRun:
             assert worker.add(task)
             assert worker.run()
             mock_run.assert_called_once()
+
+
+class _DummyTaskToCheckSkip(gokart.TaskOnKart[None]):
+    task_namespace = __name__
+
+    def _run(self): ...
+
+    def run(self):
+        self._run()
+        self.dump(None)
+
+    def complete(self) -> bool:
+        return False
+
+
+class TestWorkerSkipIfCompletedPreRun:
+    @pytest.mark.parametrize(
+        'skip_if_completed_pre_run,is_completed,expect_skipped',
+        [
+            pytest.param(True, True, True, id='skipped when completed and skip_if_completed_pre_run is True'),
+            pytest.param(True, False, False, id='not skipped when not completed and skip_if_completed_pre_run is True'),
+            pytest.param(False, True, False, id='not skipped when completed and skip_if_completed_pre_run is False'),
+            pytest.param(False, False, False, id='not skipped when not completed and skip_if_completed_pre_run is False'),
+        ],
+    )
+    def test_skip_task(self, monkeypatch: pytest.MonkeyPatch, skip_if_completed_pre_run: bool, is_completed: bool, expect_skipped: bool):
+        sch = scheduler.Scheduler()
+        worker = Worker(scheduler=sch, config=gokart_worker(skip_if_completed_pre_run=skip_if_completed_pre_run))
+
+        mock_complete = Mock(return_value=is_completed)
+        # NOTE: set `complete_check_at_run=False` to avoid using deprecated skip logic.
+        task = _DummyTaskToCheckSkip(complete_check_at_run=False)
+        mock_run = Mock()
+        monkeypatch.setattr(task, '_run', mock_run)
+
+        with worker:
+            assert worker.add(task)
+            # NOTE: mock `complete` after `add` because `add` calls `complete`
+            #       to check if the task is already completed.
+            monkeypatch.setattr(task, 'complete', mock_complete)
+            assert worker.run()
+
+            if expect_skipped:
+                mock_run.assert_not_called()
+            else:
+                mock_run.assert_called_once()


### PR DESCRIPTION
## What
* This PR implements an alternative way to skip a task when it is completed just before run
  * This feature is currently provided by `complete_check_at_run` (#333)

## Commits
* 640310c: feat: add gokart_worker configurations as same as luigi one
* 20e852f:  feat: make worker skip run when a task is completed

## Why
* `complete_check_at_run` requires to overwrite `run` function of `TaskOnKart`, which causes the issue described by #401

## Note

This PR does not affect current features because `gokart.Worker` is not used anywhere.
