### PR TITLE
Communicate Inner Task Exceptions as Part of GokartBuildError

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -117,20 +117,22 @@ class RunTest(unittest.TestCase):
         text = 'test'
         output = gokart.build(_LoadRequires(task=_DummyTask(param=text)), reset_register=False)
         self.assertEqual(output, text)
-        
+
     def test_build_with_child_task_error(self):
         class CheckException(Exception):
             pass
+
         class FailTask(gokart.TaskOnKart):
             def run(self):
                 raise CheckException()
-        
+
         try:
             t = FailTask()
             gokart.build(t, reset_register=False, log_level=logging.CRITICAL)
         except GokartBuildError as e:
             self.assertEqual(len(e.raised_exceptions), 1)
             self.assertIsInstance(e.raised_exceptions[t.make_unique_id()][0], CheckException)
+
 
 class LoggerConfigTest(unittest.TestCase):
     def test_logger_config(self):

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -117,7 +117,20 @@ class RunTest(unittest.TestCase):
         text = 'test'
         output = gokart.build(_LoadRequires(task=_DummyTask(param=text)), reset_register=False)
         self.assertEqual(output, text)
-
+        
+    def test_build_with_child_task_error(self):
+        class CheckException(Exception):
+            pass
+        class FailTask(gokart.TaskOnKart):
+            def run(self):
+                raise CheckException()
+        
+        try:
+            t = FailTask()
+            gokart.build(t, reset_register=False, log_level=logging.CRITICAL)
+        except GokartBuildError as e:
+            self.assertEqual(len(e.raised_exceptions), 1)
+            self.assertIsInstance(e.raised_exceptions[t.make_unique_id()][0], CheckException)
 
 class LoggerConfigTest(unittest.TestCase):
     def test_logger_config(self):


### PR DESCRIPTION
This PR improves error transparency in the gokart.build process by modifying how errors are captured and reported. Instead of simply throwing a GokartBuildError when a task fails, the change includes the specific exceptions raised by each task within the error itself. This is achieved by collecting exceptions through an event handler and appending them to a GokartBuildError.

Changes:

* Updated the GokartBuildError class to include a raised_exceptions property, which is a dictionary mapping task unique IDs to lists of exceptions that occurred.
