### PR TITLE
Log task ID to locate its cache

### DIFF
--- a/gokart/task.py
+++ b/gokart/task.py
@@ -540,13 +540,15 @@ If you want to specify `required_columns` and `drop_columns`, please extract the
 
     def __repr__(self):
         """
-        Build a task representation like `MyTask(param1=1.5, param2='5', data_task=DataTask(id=35tyi))`
+        Build a task representation like
+        `MyTask[aca2f28555dadd0f1e3dee3d4b973651](param1=1.5, param2='5', data_task=DataTask(c1f5d06aa580c5761c55bd83b18b0b4e))`
         """
         return self._get_task_string()
 
     def __str__(self):
         """
-        Build a human-readable task representation like `MyTask(param1=1.5, param2='5', data_task=DataTask(id=35tyi))`
+        Build a human-readable task representation like
+        `MyTask[aca2f28555dadd0f1e3dee3d4b973651](param1=1.5, param2='5', data_task=DataTask(c1f5d06aa580c5761c55bd83b18b0b4e))`
         This includes only public parameters
         """
         return self._get_task_string(only_public=True)
@@ -566,7 +568,7 @@ If you want to specify `required_columns` and `drop_columns`, please extract the
             if param_obj.significant and ((not only_public) or param_obj.visibility == ParameterVisibility.PUBLIC):
                 repr_parts.append(f'{param_name}={self._make_representation(param_obj, param_value)}')
 
-        task_str = f'{self.get_task_family()}({", ".join(repr_parts)})'
+        task_str = f'{self.get_task_family()}[{self.make_unique_id()}]({", ".join(repr_parts)})'
         return task_str
 
     def _make_representation(self, param_obj: luigi.Parameter, param_value):

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -550,9 +550,10 @@ class TaskTest(unittest.TestCase):
             task_param=_DummySubTaskWithPrivateParameter(),
             list_task_param=[_DummySubTaskWithPrivateParameter(), _DummySubTaskWithPrivateParameter()],
         )
+        task_id = task.make_unique_id()
         sub_task_id = _DummySubTaskWithPrivateParameter().make_unique_id()
         expected = (
-            f'{__name__}._DummyTaskWithPrivateParameter(int_param=1, private_int_param=1, task_param={__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), '
+            f'{__name__}._DummyTaskWithPrivateParameter[{task_id}](int_param=1, private_int_param=1, task_param={__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), '
             f'list_task_param=[{__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), {__name__}._DummySubTaskWithPrivateParameter({sub_task_id})])'
         )  # noqa:E501
         self.assertEqual(expected, repr(task))
@@ -564,9 +565,10 @@ class TaskTest(unittest.TestCase):
             task_param=_DummySubTaskWithPrivateParameter(),
             list_task_param=[_DummySubTaskWithPrivateParameter(), _DummySubTaskWithPrivateParameter()],
         )
+        task_id = task.make_unique_id()
         sub_task_id = _DummySubTaskWithPrivateParameter().make_unique_id()
         expected = (
-            f'{__name__}._DummyTaskWithPrivateParameter(int_param=1, task_param={__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), '
+            f'{__name__}._DummyTaskWithPrivateParameter[{task_id}](int_param=1, task_param={__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), '
             f'list_task_param=[{__name__}._DummySubTaskWithPrivateParameter({sub_task_id}), {__name__}._DummySubTaskWithPrivateParameter({sub_task_id})])'
         )
         self.assertEqual(expected, str(task))


### PR DESCRIPTION
## Problem

We often need the task's output (cache) to examine the failed workload. Gokart (Luigi) logs the processing status of each task but we usually search for its output by listing cloud storage objects and finding the corresponding created/updated time.

## Solution

Log the task ID, which is determined by parameters and used to name its cache file.

## Discussion

As far as I know, `__repr__` and `__str__` of `gokart.TaskOnKart` seem to be used only in logging and it does not matter to change their format. I appreciate your double-checking.
