### PR TITLE
feat: add mypy plugin options to handle missing paramters for a task

### DIFF
--- a/docs/mypy_plugin.rst
+++ b/docs/mypy_plugin.rst
@@ -64,3 +64,17 @@ Mypy plugin checks TaskOnKart generic types.
         str_task=StrTask(),  # mypy ok
         int_task=StrTask(),  # mypy error: Argument "int_task" to "StrTask" has incompatible type "StrTask"; expected "TaskOnKart[int]
     )
+
+Configurations (only pyproject.toml)
+-----------------------------------
+
+You can configure the Mypy plugin using the ``pyproject.toml`` file.
+The following options are available:
+
+.. code:: toml
+
+    [tool.gokart-mypy]
+    # If true, Mypy will raise an error if a task is missing required parameters.
+    # This configuration causes an error when the parameters set by `luigi.Config()`
+    # Default: false
+    disallow_missing_parameters = true

--- a/test/config/__init__.py
+++ b/test/config/__init__.py
@@ -3,4 +3,5 @@ from typing import Final
 
 CONFIG_DIR: Final[Path] = Path(__file__).parent.resolve()
 PYPROJECT_TOML: Final[Path] = CONFIG_DIR / 'pyproject.toml'
+PYPROJECT_TOML_SET_DISALLOW_MISSING_PARAMETERS: Final[Path] = CONFIG_DIR / 'pyproject_disallow_missing_parameters.toml'
 TEST_CONFIG_INI: Final[Path] = CONFIG_DIR / 'test_config.ini'

--- a/test/config/pyproject_disallow_missing_parameters.toml
+++ b/test/config/pyproject_disallow_missing_parameters.toml
@@ -4,3 +4,6 @@ plugins = ["gokart.mypy"]
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = ["pandas.*", "apscheduler.*", "dill.*", "boto3.*", "testfixtures.*", "luigi.*"]
+
+[tool.gokart-mypy]
+disallow_missing_parameters = true

--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -16,7 +16,6 @@ import datetime
 
 
 class MyTask(gokart.TaskOnKart):
-    # NOTE: mypy shows attr-defined error for the following lines, so we need to ignore it.
     foo: int = luigi.IntParameter() # type: ignore
     bar: str = luigi.Parameter() # type: ignore
     baz: bool = gokart.ExplicitBoolParameter()
@@ -44,7 +43,6 @@ import gokart
 
 
 class MyTask(gokart.TaskOnKart):
-    # NOTE: mypy shows attr-defined error for the following lines, so we need to ignore it.
     foo: int = luigi.IntParameter() # type: ignore
     bar: str = luigi.Parameter() # type: ignore
     baz: bool = gokart.ExplicitBoolParameter()
@@ -79,7 +77,6 @@ class MyEnum(enum.Enum):
     FOO = enum.auto()
 
 class MyTask(gokart.TaskOnKart):
-    # NOTE: mypy shows attr-defined error for the following lines, so we need to ignore it.
     foo = luigi.IntParameter()
     bar = luigi.DateParameter()
     baz = gokart.TaskInstanceParameter()
@@ -110,7 +107,6 @@ import luigi
 import gokart
 
 class MyTask(gokart.TaskOnKart):
-    # NOTE: mypy shows attr-defined error for the following lines, so we need to ignore it.
     foo = luigi.IntParameter()
     bar = luigi.DateParameter()
     baz = gokart.TaskInstanceParameter()


### PR DESCRIPTION
## Background

In this [discussion](https://github.com/m3dev/gokart/pull/384#discussion_r1685638052), I initially omitted handling errors for missing parameters in the task constructor because luigi.Config allows implicit parameters, making it difficult to validate them on linting

However, I occasionally forget to pass required parameters to tasks, leading to runtime errors when executing the pipeline.

## What

This PR introduces an option for gokart mypy to raise an error when a task constructor is called without all required parameters.

Users can configure mypy to allow implicit parameter passing if needed in their project.