### PR TITLE
add: CI on MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 5
       matrix:
         platform: [ubuntu-latest]
-        tox-env: ["py39", "py310", "py311", "py312", "py313"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
             tox-env: "py312"
           - platform: ubuntu-latest
             tox-env: "py313"
+          # test only on latest python for macos
           - platform: macos-13
             tox-env: "py313"
           - platform: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.platform }}
     strategy:
-      max-parallel: 5
+      max-parallel: 7
       matrix:
         include:
           - platform: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,21 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        platform: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-
+        include:
+          - platform: ubuntu-latest
+            tox-env: "py39"
+          - platform: ubuntu-latest
+            tox-env: "py310"
+          - platform: ubuntu-latest
+            tox-env: "py311"
+          - platform: ubuntu-latest
+            tox-env: "py312"
+          - platform: ubuntu-latest
+            tox-env: "py313"
+          - platform: macos-13
+            tox-env: "py313"
+          - platform: macos-latest
+            tox-env: "py313"
     steps:
     - uses: actions/checkout@v4
     - name: Set up the latest version of uv


### PR DESCRIPTION
related issue: https://github.com/m3dev/gokart/issues/430

While testing on MacOS is necessary, it's more expensive than Linux testing in GitHub Actions (MacOS runners consumes 10x more minutes). 
Furthermore, MacOS is rarely used in production environments, so MacOS testing is merely to verify correct functionality in local development environments. 
Therefore, I think it's sufficient to only testing for the latest Python version.

The configuration is written in a somewhat hard-to-read manner to achieve the goal of performing minimal testing on MacOS.

Desired (but unsupported) syntax:
```
matrix:
  x: [1, 2, 3, 4]
  y: [a, b, c]
  exclude:
    - x: [1, 3]
      y: [a, c]
```

Supported syntax:
```
matrix:
  x: [1, 2, 3, 4]
  y: [a, b, c]
  exclude:
    - x: 1
      y: a
    - x: 1
      y: c
    - x: 3
      y: a
    - x: 3
      y: c
```