### PR TITLE
fix: fix flaky pytest behaviors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,6 @@ check_untyped_defs = true
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-addopts = "-n auto -s -v --durations=0"
+# NOTE: `-n auto` makes pytest fast but unstable
+# ref: https://github.com/m3dev/gokart/issues/436
+addopts = "-s -v --durations=0"


### PR DESCRIPTION
### What
- It has been reported that `pytest-xdist` can cause flaky results in `pytest`.
- Removed the `-n` option from the default configuration as a temporary workaround.
- For more information, see also #436 .
