### PR TITLE
Support functionalities to provide metadata as labels to object stored in GCS as cache.

### DIFF
--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import copy
+from logging import getLogger
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import luigi
+from googleapiclient.model import makepatch
+
+from gokart.gcs_config import GCSConfig
+
+logger = getLogger(__name__)
+
+
+class GCSObjectMetadataClient(object):
+    """
+    This class is Utility-Class, so should not be initialized.
+    """
+
+    @staticmethod
+    def add_task_state_labels(
+        path: str,
+        params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None,
+    ) -> None:
+        # In gokart/object_storage.get_time_stamp, could find same call.
+        # _path_to_bucket_and_key is a private method, so, this might not be acceptable.
+        bucket, obj = GCSConfig().get_gcs_client()._path_to_bucket_and_key(path)
+
+        _response = GCSConfig().get_gcs_client().client.objects().get(bucket=bucket, object=obj).execute()
+        if _response is None:
+            logger.error(f'failed to get object from GCS bucket {bucket} and object {obj}.')
+            return
+
+        response: Dict[str, Any] = dict(_response)
+        original_metadata: Dict[Any, Any] = {}
+        if 'metadata' in response.keys():
+            _metadata = response.get('metadata')
+            if _metadata is not None:
+                original_metadata = dict(_metadata)
+
+        patched_metadata = GCSObjectMetadataClient._get_patched_obj_metadata(
+            copy.deepcopy(original_metadata),
+            params,
+        )
+
+        if not original_metadata == patched_metadata:
+            # If we use update api, existing object metadata are removed, so should use patch api.
+            # See the official document descriptions.
+            # [Link] https://cloud.google.com/storage/docs/viewing-editing-metadata?hl=ja#rest-set-object-metadata
+            update_response = (
+                GCSConfig()
+                .get_gcs_client()
+                .client.objects()
+                .patch(
+                    bucket=bucket,
+                    object=obj,
+                    body=makepatch({'metadata': original_metadata}, {'metadata': patched_metadata}),
+                )
+                .execute()
+            )
+
+            if update_response is None:
+                logger.error(f'failed to patch object {obj} in bucket {bucket} and object {obj}.')
+
+    @staticmethod
+    def _get_patched_obj_metadata(
+        metadata: Any,
+        params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None,
+    ) -> Union[Dict, Any]:
+        # If metadata from response when getting bucket and object information is not dictionary,
+        # something wrong might be happened, so return original metadata, no patched.
+        if not isinstance(metadata, dict):
+            logger.warning(f'metadata is not a dict: {metadata}, something wrong was happened when getting response when get bucket and object information.')
+            return metadata
+
+        # Maximum size of metadata for each object is 8KiB.
+        # [Link]: https://cloud.google.com/storage/quotas?hl=ja#objects
+        # And also, user_provided_labels should be prioritized rather than auto generated labels.
+        # So, at first, attach user_provided_labels, then add auto generated labels.
+        max_gcs_metadata_size, total_metadata_size, labels = 8 * 1024, 0, []
+        if params:
+            all_labels = GCSObjectMetadataClient._merge_with_user_provided_labels(params)
+            for label_name, label_value in all_labels:
+                size = len(str(label_name).encode('utf-8')) + len(str(label_value).encode('utf-8'))
+                if total_metadata_size + size > max_gcs_metadata_size:
+                    logger.warning(f'current metadata total size is {total_metadata_size} byte, and no more labels would be added.')
+                    break
+                total_metadata_size += size
+                labels.append((label_name, str(label_value)))
+
+        patched_metadata = dict(metadata)
+        for label_key, label_value in labels:
+            patched_metadata[label_key] = label_value
+        return patched_metadata
+
+    @staticmethod
+    def _merge_with_user_provided_labels(
+        params: List[Tuple[str, Any, luigi.Parameter]],
+    ) -> List[Tuple[Any, Any]]:
+        # luigi.Parameter.get_param_names() returns significant parameters only.
+        # [Link]: https://luigi.readthedocs.io/en/latest/_modules/luigi/task.html#Task.get_param_names
+        parameter_labels, parameter_key_set = [], set()
+
+        for param_name, param_value, param_obj in params:
+            if param_name == 'user_provided_gcs_labels':
+                continue
+            if param_value is None:
+                logger.warning(f'param_name={param_name} param_obj={param_obj} param_value is None. So skipped.')
+                continue
+            parameter_labels.append((param_name, param_value)) if param_obj.significant else None
+            parameter_key_set.add(param_name)
+        # Make user_provided override parameter when their key conflict.
+        # Log a warning message when this happens.
+        for param_name, param_value, _ in params:
+            if param_name == 'user_provided_gcs_labels':
+                user_provided_labels = dict(param_value)
+                for up_key, up_value in user_provided_labels.items():
+                    if up_key in parameter_key_set:
+                        logger.warning(f"{up_key} is already in parameter's name set. Override it's value with {up_value} from user provided labels.")
+                    parameter_labels.append((up_key, up_value))
+        return parameter_labels

--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import copy
 from logging import getLogger
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 from urllib.parse import urlsplit
 
-import luigi
 from googleapiclient.model import makepatch
 
 from gokart.gcs_config import GCSConfig
@@ -13,7 +12,7 @@ from gokart.gcs_config import GCSConfig
 logger = getLogger(__name__)
 
 
-class GCSObjectMetadataClient(object):
+class GCSObjectMetadataClient:
     """
     This class is Utility-Class, so should not be initialized.
     This class used for adding metadata as labels.
@@ -21,7 +20,7 @@ class GCSObjectMetadataClient(object):
 
     # This is the copied method of luigi.gcs._path_to_bucket_and_key(path).
     @staticmethod
-    def path_to_bucket_and_key(path):
+    def path_to_bucket_and_key(path: str) -> tuple[str, str]:
         (scheme, netloc, path, _, _) = urlsplit(path)
         assert scheme == 'gs'
         path_without_initial_slash = path[1:]
@@ -30,7 +29,7 @@ class GCSObjectMetadataClient(object):
     @staticmethod
     def add_task_state_labels(
         path: str,
-        params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None,
+        params: Optional[dict[Any, str]] = None,
     ) -> None:
         # In gokart/object_storage.get_time_stamp, could find same call.
         # _path_to_bucket_and_key is a private method, so, this might not be acceptable.
@@ -75,26 +74,27 @@ class GCSObjectMetadataClient(object):
     @staticmethod
     def _get_patched_obj_metadata(
         metadata: Any,
-        params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None,
-    ) -> Union[Dict, Any]:
+        params: Optional[dict[Any, str]] = None,
+    ) -> Union[dict, Any]:
         # If metadata from response when getting bucket and object information is not dictionary,
         # something wrong might be happened, so return original metadata, no patched.
         if not isinstance(metadata, dict):
             logger.warning(f'metadata is not a dict: {metadata}, something wrong was happened when getting response when get bucket and object information.')
             return metadata
 
+        if not params:
+            return metadata
         # Maximum size of metadata for each object is 8 KiB.
         # [Link]: https://cloud.google.com/storage/quotas#objects
         max_gcs_metadata_size, total_metadata_size, labels = 8 * 1024, 0, []
-        if params:
-            for label_name, label_value, _ in params:
-                if label_value is None:
-                    continue
-                size = len(str(label_name).encode('utf-8')) + len(str(label_value).encode('utf-8'))
-                if total_metadata_size + size > max_gcs_metadata_size:
-                    logger.warning(f'current metadata total size is {total_metadata_size} byte, and no more labels would be added.')
-                    break
-                total_metadata_size += size
-                labels.append((label_name, str(label_value)))
-
+        for label_name, label_value in params.items():
+            if len(label_value) == 0:
+                logger.warning(f'value of label_name={label_name} is empty. So skip to add as a metadata.')
+                continue
+            size = len(str(label_name).encode('utf-8')) + len(str(label_value).encode('utf-8'))
+            if total_metadata_size + size > max_gcs_metadata_size:
+                logger.warning(f'current metadata total size is {total_metadata_size} byte, and no more labels would be added.')
+                break
+            total_metadata_size += size
+            labels.append((label_name, label_value))
         return dict(metadata) | dict(labels)

--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -41,8 +41,8 @@ class GCSObjectMetadataClient(object):
             logger.error(f'failed to get object from GCS bucket {bucket} and object {obj}.')
             return
 
-        response: Dict[str, Any] = dict(_response)
-        original_metadata: Dict[Any, Any] = {}
+        response: dict[str, Any] = dict(_response)
+        original_metadata: dict[Any, Any] = {}
         if 'metadata' in response.keys():
             _metadata = response.get('metadata')
             if _metadata is not None:

--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -83,8 +83,8 @@ class GCSObjectMetadataClient(object):
             logger.warning(f'metadata is not a dict: {metadata}, something wrong was happened when getting response when get bucket and object information.')
             return metadata
 
-        # Maximum size of metadata for each object is 8KiB.
-        # [Link]: https://cloud.google.com/storage/quotas?hl=ja#objects
+        # Maximum size of metadata for each object is 8 KiB.
+        # [Link]: https://cloud.google.com/storage/quotas#objects
         max_gcs_metadata_size, total_metadata_size, labels = 8 * 1024, 0, []
         if params:
             for label_name, label_value, _ in params:
@@ -97,7 +97,4 @@ class GCSObjectMetadataClient(object):
                 total_metadata_size += size
                 labels.append((label_name, str(label_value)))
 
-        patched_metadata = dict(metadata)
-        for label_key, label_value in labels:
-            patched_metadata[label_key] = label_value
-        return patched_metadata
+        return dict(metadata) | dict(labels)

--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -29,7 +29,7 @@ class GCSObjectMetadataClient:
     @staticmethod
     def add_task_state_labels(
         path: str,
-        params: Optional[dict[Any, str]] = None,
+        task_params: Optional[dict[Any, str]] = None,
     ) -> None:
         # In gokart/object_storage.get_time_stamp, could find same call.
         # _path_to_bucket_and_key is a private method, so, this might not be acceptable.
@@ -49,7 +49,7 @@ class GCSObjectMetadataClient:
 
         patched_metadata = GCSObjectMetadataClient._get_patched_obj_metadata(
             copy.deepcopy(original_metadata),
-            params,
+            task_params,
         )
 
         if original_metadata != patched_metadata:
@@ -74,7 +74,7 @@ class GCSObjectMetadataClient:
     @staticmethod
     def _get_patched_obj_metadata(
         metadata: Any,
-        params: Optional[dict[Any, str]] = None,
+        task_params: Optional[dict[Any, str]] = None,
     ) -> Union[dict, Any]:
         # If metadata from response when getting bucket and object information is not dictionary,
         # something wrong might be happened, so return original metadata, no patched.
@@ -82,12 +82,12 @@ class GCSObjectMetadataClient:
             logger.warning(f'metadata is not a dict: {metadata}, something wrong was happened when getting response when get bucket and object information.')
             return metadata
 
-        if not params:
+        if not task_params:
             return metadata
         # Maximum size of metadata for each object is 8 KiB.
         # [Link]: https://cloud.google.com/storage/quotas#objects
         max_gcs_metadata_size, total_metadata_size, labels = 8 * 1024, 0, []
-        for label_name, label_value in params.items():
+        for label_name, label_value in task_params.items():
             if len(label_value) == 0:
                 logger.warning(f'value of label_name={label_name} is empty. So skip to add as a metadata.')
                 continue

--- a/gokart/in_memory/target.py
+++ b/gokart/in_memory/target.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import luigi
 
@@ -26,7 +26,7 @@ class InMemoryTarget(TargetOnKart):
     def _load(self) -> Any:
         return _repository.get_value(self._data_key)
 
-    def _dump(self, obj: Any, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj: Any, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
         return _repository.set_value(self._data_key, obj)
 
     def _remove(self) -> None:

--- a/gokart/in_memory/target.py
+++ b/gokart/in_memory/target.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, List, Optional, Tuple
+
+import luigi
 
 from gokart.in_memory.repository import InMemoryCacheRepository
 from gokart.target import TargetOnKart, TaskLockParams
@@ -24,7 +26,7 @@ class InMemoryTarget(TargetOnKart):
     def _load(self) -> Any:
         return _repository.get_value(self._data_key)
 
-    def _dump(self, obj: Any) -> None:
+    def _dump(self, obj: Any, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
         return _repository.set_value(self._data_key, obj)
 
     def _remove(self) -> None:

--- a/gokart/in_memory/target.py
+++ b/gokart/in_memory/target.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from typing import Any, Optional
 
-import luigi
-
 from gokart.in_memory.repository import InMemoryCacheRepository
 from gokart.target import TargetOnKart, TaskLockParams
 
@@ -26,7 +24,7 @@ class InMemoryTarget(TargetOnKart):
     def _load(self) -> Any:
         return _repository.get_value(self._data_key)
 
-    def _dump(self, obj: Any, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj: Any, params: Optional[dict[Any, str]] = None) -> None:
         return _repository.set_value(self._data_key, obj)
 
     def _remove(self) -> None:

--- a/gokart/in_memory/target.py
+++ b/gokart/in_memory/target.py
@@ -24,7 +24,7 @@ class InMemoryTarget(TargetOnKart):
     def _load(self) -> Any:
         return _repository.get_value(self._data_key)
 
-    def _dump(self, obj: Any, params: Optional[dict[Any, str]] = None) -> None:
+    def _dump(self, obj: Any, task_params: Optional[dict[Any, str]] = None) -> None:
         return _repository.set_value(self._data_key, obj)
 
     def _remove(self) -> None:

--- a/gokart/in_memory/target.py
+++ b/gokart/in_memory/target.py
@@ -24,7 +24,7 @@ class InMemoryTarget(TargetOnKart):
     def _load(self) -> Any:
         return _repository.get_value(self._data_key)
 
-    def _dump(self, obj: Any, task_params: Optional[dict[Any, str]] = None) -> None:
+    def _dump(self, obj: Any, task_params: Optional[dict[str, str]] = None) -> None:
         return _repository.set_value(self._data_key, obj)
 
     def _remove(self) -> None:

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from datetime import datetime
 from glob import glob
 from logging import getLogger
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import luigi
 import numpy as np
@@ -28,7 +28,7 @@ class TargetOnKart(luigi.Target):
     def load(self) -> Any:
         return wrap_load_with_lock(func=self._load, task_lock_params=self._get_task_lock_params())()
 
-    def dump(self, obj, lock_at_dump: bool = True, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def dump(self, obj, lock_at_dump: bool = True, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
         if lock_at_dump:
             wrap_dump_with_lock(func=self._dump, task_lock_params=self._get_task_lock_params(), exist_check=self.exists)(obj=obj, params=params)
         else:
@@ -57,7 +57,7 @@ class TargetOnKart(luigi.Target):
         pass
 
     @abstractmethod
-    def _dump(self, obj, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
         pass
 
     @abstractmethod
@@ -94,7 +94,7 @@ class SingleFileTarget(TargetOnKart):
         with self._target.open('r') as f:
             return self._processor.load(f)
 
-    def _dump(self, obj, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
         with self._target.open('w') as f:
             self._processor.dump(obj, f)
         if self.path().startswith('gs://'):
@@ -138,7 +138,7 @@ class ModelTarget(TargetOnKart):
         self._remove_temporary_directory()
         return model
 
-    def _dump(self, obj, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
         self._make_temporary_directory()
         self._save_function(obj, self._model_path())
         make_target(self._load_function_path()).dump(self._load_function, params=params)

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -28,7 +28,7 @@ class TargetOnKart(luigi.Target):
     def load(self) -> Any:
         return wrap_load_with_lock(func=self._load, task_lock_params=self._get_task_lock_params())()
 
-    def dump(self, obj, lock_at_dump: bool = True, task_params: Optional[dict[Any, str]] = None) -> None:
+    def dump(self, obj, lock_at_dump: bool = True, task_params: Optional[dict[str, str]] = None) -> None:
         if lock_at_dump:
             wrap_dump_with_lock(func=self._dump, task_lock_params=self._get_task_lock_params(), exist_check=self.exists)(obj=obj, task_params=task_params)
         else:
@@ -57,7 +57,7 @@ class TargetOnKart(luigi.Target):
         pass
 
     @abstractmethod
-    def _dump(self, obj, task_params: Optional[dict[Any, str]] = None) -> None:
+    def _dump(self, obj, task_params: Optional[dict[str, str]] = None) -> None:
         pass
 
     @abstractmethod
@@ -94,7 +94,7 @@ class SingleFileTarget(TargetOnKart):
         with self._target.open('r') as f:
             return self._processor.load(f)
 
-    def _dump(self, obj, task_params: Optional[dict[Any, str]] = None) -> None:
+    def _dump(self, obj, task_params: Optional[dict[str, str]] = None) -> None:
         with self._target.open('w') as f:
             self._processor.dump(obj, f)
         if self.path().startswith('gs://'):
@@ -138,7 +138,7 @@ class ModelTarget(TargetOnKart):
         self._remove_temporary_directory()
         return model
 
-    def _dump(self, obj, task_params: Optional[dict[Any, str]] = None) -> None:
+    def _dump(self, obj, task_params: Optional[dict[str, str]] = None) -> None:
         self._make_temporary_directory()
         self._save_function(obj, self._model_path())
         make_target(self._load_function_path()).dump(self._load_function, task_params=task_params)

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -28,7 +28,7 @@ class TargetOnKart(luigi.Target):
     def load(self) -> Any:
         return wrap_load_with_lock(func=self._load, task_lock_params=self._get_task_lock_params())()
 
-    def dump(self, obj, lock_at_dump: bool = True, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def dump(self, obj, lock_at_dump: bool = True, params: Optional[dict[Any, str]] = None) -> None:
         if lock_at_dump:
             wrap_dump_with_lock(func=self._dump, task_lock_params=self._get_task_lock_params(), exist_check=self.exists)(obj=obj, params=params)
         else:
@@ -57,7 +57,7 @@ class TargetOnKart(luigi.Target):
         pass
 
     @abstractmethod
-    def _dump(self, obj, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj, params: Optional[dict[Any, str]] = None) -> None:
         pass
 
     @abstractmethod
@@ -94,7 +94,7 @@ class SingleFileTarget(TargetOnKart):
         with self._target.open('r') as f:
             return self._processor.load(f)
 
-    def _dump(self, obj, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj, params: Optional[dict[Any, str]] = None) -> None:
         with self._target.open('w') as f:
             self._processor.dump(obj, f)
         if self.path().startswith('gs://'):
@@ -138,7 +138,7 @@ class ModelTarget(TargetOnKart):
         self._remove_temporary_directory()
         return model
 
-    def _dump(self, obj, params: Optional[list[tuple[str, Any, luigi.Parameter]]] = None) -> None:
+    def _dump(self, obj, params: Optional[dict[Any, str]] = None) -> None:
         self._make_temporary_directory()
         self._save_function(obj, self._model_path())
         make_target(self._load_function_path()).dump(self._load_function, params=params)

--- a/gokart/target.py
+++ b/gokart/target.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from datetime import datetime
 from glob import glob
 from logging import getLogger
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 import luigi
 import numpy as np
@@ -14,6 +14,7 @@ import pandas as pd
 from gokart.conflict_prevention_lock.task_lock import TaskLockParams, make_task_lock_params
 from gokart.conflict_prevention_lock.task_lock_wrappers import wrap_dump_with_lock, wrap_load_with_lock, wrap_remove_with_lock
 from gokart.file_processor import FileProcessor, make_file_processor
+from gokart.gcs_obj_metadata_client import GCSObjectMetadataClient
 from gokart.object_storage import ObjectStorage
 from gokart.zip_client_util import make_zip_client
 
@@ -27,11 +28,11 @@ class TargetOnKart(luigi.Target):
     def load(self) -> Any:
         return wrap_load_with_lock(func=self._load, task_lock_params=self._get_task_lock_params())()
 
-    def dump(self, obj, lock_at_dump: bool = True) -> None:
+    def dump(self, obj, lock_at_dump: bool = True, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
         if lock_at_dump:
-            wrap_dump_with_lock(func=self._dump, task_lock_params=self._get_task_lock_params(), exist_check=self.exists)(obj)
+            wrap_dump_with_lock(func=self._dump, task_lock_params=self._get_task_lock_params(), exist_check=self.exists)(obj=obj, params=params)
         else:
-            self._dump(obj)
+            self._dump(obj=obj, params=params)
 
     def remove(self) -> None:
         if self.exists():
@@ -56,7 +57,7 @@ class TargetOnKart(luigi.Target):
         pass
 
     @abstractmethod
-    def _dump(self, obj) -> None:
+    def _dump(self, obj, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
         pass
 
     @abstractmethod
@@ -93,9 +94,11 @@ class SingleFileTarget(TargetOnKart):
         with self._target.open('r') as f:
             return self._processor.load(f)
 
-    def _dump(self, obj) -> None:
+    def _dump(self, obj, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
         with self._target.open('w') as f:
             self._processor.dump(obj, f)
+        if self.path().startswith('gs://'):
+            GCSObjectMetadataClient.add_task_state_labels(path=self.path(), params=params)
 
     def _remove(self) -> None:
         self._target.remove()
@@ -135,10 +138,10 @@ class ModelTarget(TargetOnKart):
         self._remove_temporary_directory()
         return model
 
-    def _dump(self, obj) -> None:
+    def _dump(self, obj, params: Optional[List[Tuple[str, Any, luigi.Parameter]]] = None) -> None:
         self._make_temporary_directory()
         self._save_function(obj, self._model_path())
-        make_target(self._load_function_path()).dump(self._load_function)
+        make_target(self._load_function_path()).dump(self._load_function, params=params)
         self._zip_client.make_archive()
         self._remove_temporary_directory()
 

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -105,7 +105,6 @@ class TaskOnKart(luigi.Task, Generic[T]):
         default=True, description='Check if output file exists at run. If exists, run() will be skipped.', significant=False
     )
     should_lock_run: bool = ExplicitBoolParameter(default=False, significant=False, description='Whether to use redis lock or not at task run.')
-    user_provided_gcs_labels: Dict = luigi.DictParameter(default={}, significant=False, description='User-provided labels for gcs cache label..')
 
     @property
     def priority(self):

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -360,7 +360,7 @@ If you want to specify `required_columns` and `drop_columns`, please extract the
         if self.fail_on_empty_dump and isinstance(obj, pd.DataFrame):
             assert not obj.empty
 
-        self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, params=super().to_str_params(only_significant=True))
+        self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, task_params=super().to_str_params(only_significant=True))
 
     @staticmethod
     def get_code(target_class) -> Set[str]:

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -360,8 +360,7 @@ If you want to specify `required_columns` and `drop_columns`, please extract the
         if self.fail_on_empty_dump and isinstance(obj, pd.DataFrame):
             assert not obj.empty
 
-        params = [(param_name, self.param_kwargs[param_name], param_obj) for param_name, param_obj in self.get_params() if param_obj.significant]
-        self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, params=params)
+        self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, params=super().to_str_params(only_significant=True))
 
     @staticmethod
     def get_code(target_class) -> Set[str]:

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -360,10 +360,7 @@ If you want to specify `required_columns` and `drop_columns`, please extract the
         if self.fail_on_empty_dump and isinstance(obj, pd.DataFrame):
             assert not obj.empty
 
-        params = []
-        for param_name, param_obj in self.get_params():
-            params.append((param_name, self.param_kwargs[param_name], param_obj)) if param_obj.significant else None
-
+        params = [(param_name, self.param_kwargs[param_name], param_obj) for param_name, param_obj in self.get_params() if param_obj.significant]
         self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, params=params)
 
     @staticmethod

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -360,7 +360,7 @@ If you want to specify `required_columns` and `drop_columns`, please extract the
         if self.fail_on_empty_dump and isinstance(obj, pd.DataFrame):
             assert not obj.empty
 
-        self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, task_params=super().to_str_params(only_significant=True))
+        self._get_output_target(target).dump(obj, lock_at_dump=self._lock_at_dump, task_params=super().to_str_params(only_significant=True, only_public=True))
 
     @staticmethod
     def get_code(target_class) -> Set[str]:

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -17,7 +17,7 @@ class _DummyTaskOnKart(gokart.TaskOnKart):
 
 class TestGCSObjectMetadataClient(unittest.TestCase):
     def test_get_patched_obj_metadata(self):
-        params: dict[Any, str] = {
+        task_params: dict[Any, str] = {
             'param1': 'a' * 1000,
             'param2': str(1000),
             'param3': str({'key1': 'value1', 'key2': True, 'key3': 2}),
@@ -25,7 +25,7 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
             'param5': str(datetime.datetime(year=2025, month=1, day=2, hour=3, minute=4, second=5)),
             'param6': '',
         }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, task_params=task_params)
         self.assertIsInstance(got, dict)
         self.assertIn('param1', got)
         self.assertIn('param2', got)
@@ -35,14 +35,14 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         self.assertNotIn('param6', got)
 
     def test_get_patched_obj_metadata_with_exceeded_size_metadata(self):
-        params = {
+        task_params = {
             'param1': 'a' * 5000,
             'param2': 'b' * 5000,
         }
         want = {
             'param1': 'a' * 5000,
         }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, task_params=task_params)
         self.assertEqual(got, want)
 
 
@@ -55,7 +55,7 @@ class TestGokartTask(unittest.TestCase):
         task = _DummyTaskOnKart()
         task.dump({'key': 'value'}, mock_target)
 
-        mock_target.dump.assert_called_once_with({'key': 'value'}, lock_at_dump=task._lock_at_dump, params={})
+        mock_target.dump.assert_called_once_with({'key': 'value'}, lock_at_dump=task._lock_at_dump, task_params={})
 
 
 if __name__ == '__main__':

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -1,30 +1,11 @@
-# mypy: ignore-errors
-# The reason why this file ignore mypy errors is luigi.Parameter specification.
-# There are no ways to get luigi.Parameter instance.
-# In _get_patched_obj_metadata(), params arguments type is list[tuple[str, Any, luigi.Parameter]],
-# so, even if in this file, we need to cast params to list[tuple[str, Any, luigi.Parameter]].
-# But by luigi's specification, we get string value, which is parameter value instead of luigi.Parameter instance.
-
 import datetime
-import enum
 import unittest
+from typing import Any
 from unittest.mock import MagicMock, patch
-
-import luigi
 
 import gokart
 from gokart.gcs_obj_metadata_client import GCSObjectMetadataClient
 from gokart.target import TargetOnKart
-
-
-class _DummyTask(luigi.Task):
-    task_namespace = __name__
-
-    def run(self):
-        print(f'{self.__class__.__name__} has been executed')
-
-    def complete(self):
-        return True
 
 
 class _DummyTaskOnKart(gokart.TaskOnKart):
@@ -34,395 +15,30 @@ class _DummyTaskOnKart(gokart.TaskOnKart):
         self.dump('Dummy TaskOnKart')
 
 
-class _DummyEnum(enum.Enum):
-    hoge = 1
-    fuga = 2
-    geho = 3
-
-
 class TestGCSObjectMetadataClient(unittest.TestCase):
-    def test_get_patched_normal_parameter(self):
-        param1 = luigi.Parameter(default='param1_value')
-        params = [
-            ('param1', 'param1_value', param1),
-        ]
-        want = {
-            'param1': 'param1_value',
+    def test_get_patched_obj_metadata(self):
+        params: dict[Any, str] = {
+            'param1': 'a' * 1000,
+            'param2': str(1000),
+            'param3': str({'key1': 'value1', 'key2': True, 'key3': 2}),
+            'param4': str([1, 2, 3, 4, 5]),
+            'param5': str(datetime.datetime(year=2025, month=1, day=2, hour=3, minute=4, second=5)),
+            'param6': '',
         }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_optional_parameter(self):
-        param1 = luigi.OptionalParameter(default=None)
-        param2 = luigi.OptionalParameter(default='optional')
-
-        params = [
-            ('param1', None, param1),
-            ('param2', 'optional', param2),
-        ]
-        want = {
-            'param2': 'optional',
-        }
-
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_optional_str_parameter(self):
-        param1 = luigi.OptionalStrParameter(default=None)
-        param2 = luigi.OptionalStrParameter(default='optional string')
-        params = [
-            ('param1', None, param1),
-            ('param2', 'optional string', param2),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertNotIn('param1', got)
+        self.assertIsInstance(got, dict)
+        self.assertIn('param1', got)
         self.assertIn('param2', got)
-        self.assertEqual('optional string', got['param2'])
-
-    def test_get_patched_date_parameter(self):
-        param1 = luigi.DateParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('6' in got['param1'])
-        self.assertFalse('4' in got['param1'])
-
-    def test_get_patched_month_parameter(self):
-        param1 = luigi.MonthParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('5' in got['param1'])
-        self.assertFalse('6' in got['param1'])
-
-    def test_get_patched_year_parameter(self):
-        param1 = luigi.YearParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('1789' in got['param1'])
-        self.assertFalse('5' in got['param1'])
-
-    def test_get_patched_date_hour_parameter(self):
-        param1 = luigi.DateHourParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('4' in got['param1'])
-        self.assertFalse('2' in got['param1'])
-
-    def test_get_patched_date_minute_parameter(self):
-        param1 = luigi.DateMinuteParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('2' in got['param1'])
-        self.assertFalse('3' in got['param1'])
-
-    def test_get_patched_date_second_parameter(self):
-        param1 = luigi.DateSecondParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('3' in got['param1'])
-
-    def test_get_patched_int_parameter(self):
-        param1 = luigi.IntParameter(default=100)
-        params = [
-            ('param1', 100, param1),
-        ]
-        want = {
-            'param1': '100',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_optional_int_parameter(self):
-        param1 = luigi.OptionalIntParameter(default=None)
-        param2 = luigi.OptionalIntParameter(default=10)
-        params = [('param1', None, param1), ('param2', 10, param2)]
-        want = {
-            'param2': '10',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_float_parameter(self):
-        param1 = luigi.FloatParameter(default=1.234)
-        params = [
-            ('param1', 1.234, param1),
-        ]
-        want = {
-            'param1': '1.234',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_optional_float_parameter(self):
-        param1 = luigi.OptionalFloatParameter(default=None)
-        param2 = luigi.OptionalFloatParameter(default=12.345)
-        params = [
-            ('param1', None, param1),
-            ('param2', 12.345, param2),
-        ]
-        want = {
-            'param2': '12.345',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_bool_parameter(self):
-        param1 = luigi.BoolParameter(default=False)
-        params = [
-            ('param1', False, param1),
-        ]
-        want = {
-            'param1': 'False',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_optional_bool_parameter(self):
-        param1 = luigi.OptionalBoolParameter(default=None)
-        param2 = luigi.OptionalBoolParameter(default=True)
-        params = [
-            ('param1', None, param1),
-            ('param2', True, param2),
-        ]
-        want = {
-            'param2': 'True',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_date_interval_parameter(self):
-        param1 = luigi.DateIntervalParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
-        params = [
-            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertEqual(got['param1'], '1789-05-06 04:02:03')
-
-    def test_get_patched_time_delta_parameter(self):
-        param1 = luigi.TimeDeltaParameter(default=datetime.timedelta(hours=1))
-        params = [
-            ('param1', datetime.timedelta(hours=1), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertEqual(got['param1'], '1:00:00')
-
-    def test_get_patched_task_parameter(self):
-        param1 = luigi.TaskParameter(default=_DummyTask())
-        params = [
-            ('param1', _DummyTask(), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('_DummyTask' in got['param1'])
-
-    def test_get_patched_enum_parameter(self):
-        param1 = luigi.EnumParameter(enum=_DummyEnum, default=_DummyEnum.hoge)
-        params = [
-            ('param1', _DummyEnum.hoge, param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('_DummyEnum.hoge' in got['param1'])
-
-    def test_get_patched_enum_list_parameter(self):
-        param1 = luigi.EnumParameter(enum=_DummyEnum, default=[_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho])
-        params = [
-            ('param1', [_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho], param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('_DummyEnum.hoge' in got['param1'])
-        self.assertTrue('_DummyEnum.fuga' in got['param1'])
-        self.assertTrue('_DummyEnum.geho' in got['param1'])
-
-    def test_get_patched_dict_parameter(self):
-        param1 = luigi.DictParameter(default={'color': 'red', 'id': 123, 'is_test': True})
-        params = [
-            ('param1', {'color': 'red', 'id': 123, 'is_test': True}, param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('color' in got['param1'])
-        self.assertTrue('red' in got['param1'])
-        self.assertTrue('id' in got['param1'])
-        self.assertTrue('123' in got['param1'])
-        self.assertTrue('is_test' in got['param1'])
-        self.assertTrue('True' in got['param1'])
-
-    def test_get_patched_optional_dict_parameter(self):
-        param1 = luigi.OptionalDictParameter(default=None)
-        param2 = luigi.OptionalDictParameter(default={'color': 'red', 'id': 123, 'is_test': True})
-        params = [
-            ('param1', None, param1),
-            ('param2', {'color': 'red', 'id': 123, 'is_test': True}, param2),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertNotIn('param1', got)
-        self.assertIn('param2', got)
-        self.assertIsInstance(got['param2'], str)
-        self.assertTrue('color' in got['param2'])
-        self.assertTrue('red' in got['param2'])
-        self.assertTrue('id' in got['param2'])
-        self.assertTrue('123' in got['param2'])
-        self.assertTrue('is_test' in got['param2'])
-        self.assertTrue('True' in got['param2'])
-
-    def test_get_patched_list_parameter(self):
-        param1 = luigi.ListParameter(default=[1, 2, 3, 4, 5])
-        params = [
-            ('param1', [1, 2, 3, 4, 5], param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('1' in got['param1'])
-        self.assertTrue('2' in got['param1'])
-        self.assertTrue('3' in got['param1'])
-        self.assertTrue('4' in got['param1'])
-        self.assertTrue('5' in got['param1'])
-
-    def test_get_patched_optional_list_parameter(self):
-        param1 = luigi.OptionalListParameter(default=None)
-        param2 = luigi.ListParameter(default=[1, 2, 3, 4, 5])
-        params = [
-            ('param1', None, param1),
-            ('param2', [1, 2, 3, 4, 5], param2),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertNotIn('param1', got)
-        self.assertIn('param2', got)
-        self.assertIsInstance(got['param2'], str)
-        self.assertTrue('1' in got['param2'])
-        self.assertTrue('2' in got['param2'])
-        self.assertTrue('3' in got['param2'])
-        self.assertTrue('4' in got['param2'])
-        self.assertTrue('5' in got['param2'])
-
-    def test_get_patched_tuple_parameter(self):
-        param1 = luigi.TupleParameter(default=('hoge', 1, True, {'a': 'b'}))
-        params = [
-            ('param1', ('hoge', 1, True, {'a': 'b'}), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('hoge' in got['param1'])
-        self.assertTrue('1' in got['param1'])
-        self.assertTrue('True' in got['param1'])
-        self.assertTrue('a' in got['param1'])
-        self.assertTrue('b' in got['param1'])
-
-    def test_get_patched_optional_tuple_parameter(self):
-        param1 = luigi.OptionalTupleParameter(default=None)
-        param2 = luigi.TupleParameter(default=('hoge', 1, True, {'a': 'b'}))
-        params = [
-            ('param1', None, param1),
-            ('param2', ('hoge', 1, True, {'a': 'b'}), param2),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertNotIn('param1', got)
-        self.assertIn('param2', got)
-        self.assertIsInstance(got['param2'], str)
-        self.assertTrue('hoge' in got['param2'])
-        self.assertTrue('1' in got['param2'])
-        self.assertTrue('True' in got['param2'])
-        self.assertTrue('a' in got['param2'])
-        self.assertTrue('b' in got['param2'])
-
-    def test_get_patched_path_parameter(self):
-        param1 = luigi.PathParameter(default='/hoge/fuga')
-        params = [
-            ('param1', '/hoge/fuga', param1),
-        ]
-        want = {
-            'param1': '/hoge/fuga',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    def test_get_patched_optional_path_parameter(self):
-        param1 = luigi.OptionalPathParameter(default=None)
-        param2 = luigi.OptionalPathParameter(default='/hoge/fuga')
-        params = [
-            ('param1', None, param1),
-            ('param2', '/hoge/fuga', param2),
-        ]
-        want = {
-            'param2': '/hoge/fuga',
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
-
-    # gokart specific parameter test
-    def test_get_patched_task_instance_parameter(self):
-        param1 = gokart.TaskInstanceParameter(default=_DummyTaskOnKart())
-        params = [
-            ('param1', str(_DummyTaskOnKart()), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertIn('param1', got)
-        self.assertIsInstance(got['param1'], str)
-        self.assertTrue('_DummyTaskOnKart' in got['param1'])
-
-    def test_get_patched_list_task_instance_parameter(self):
-        param1 = gokart.ListTaskInstanceParameter(default=[_DummyTaskOnKart(), _DummyTaskOnKart()])
-        params = [
-            ('param1', str([_DummyTaskOnKart(), _DummyTaskOnKart()]), param1),
-        ]
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertTrue(got['param1'].count('_DummyTaskOnKart') == 2)
-
-    def test_get_patched_explicit_bool_parameter(self):
-        param1 = gokart.ExplicitBoolParameter(default=True)
-        params = [
-            ('param1', str(True), param1),
-        ]
-        want = {
-            'param1': str(True),
-        }
-        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param3', got)
+        self.assertIn('param4', got)
+        self.assertIn('param5', got)
+        self.assertNotIn('param6', got)
 
     def test_get_patched_obj_metadata_with_exceeded_size_metadata(self):
-        param1 = luigi.Parameter(default='a' * 5000)
-        param2 = luigi.Parameter(default='b' * 5000)
-
-        params = [
-            ('param1', 'a' * 5000, param1),
-            ('param2', 'b' * 5000, param2),
-        ]
-
+        params = {
+            'param1': 'a' * 5000,
+            'param2': 'b' * 5000,
+        }
         want = {
             'param1': 'a' * 5000,
         }
@@ -431,16 +47,15 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
 
 
 class TestGokartTask(unittest.TestCase):
-    @patch('gokart.target.TargetOnKart.dump')
     @patch.object(_DummyTaskOnKart, '_get_output_target')
-    def test_mock_target_on_kart(self, mock_get_output_target, mock_dump):
+    def test_mock_target_on_kart(self, mock_get_output_target):
         mock_target = MagicMock(spec=TargetOnKart)
         mock_get_output_target.return_value = mock_target
 
         task = _DummyTaskOnKart()
         task.dump({'key': 'value'}, mock_target)
 
-        mock_target.dump.assert_called_once_with({'key': 'value'}, lock_at_dump=task._lock_at_dump, params=[])
+        mock_target.dump.assert_called_once_with({'key': 'value'}, lock_at_dump=task._lock_at_dump, params={})
 
 
 if __name__ == '__main__':

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import unittest
 
 import luigi
@@ -6,48 +7,362 @@ import luigi
 from gokart.gcs_obj_metadata_client import GCSObjectMetadataClient
 
 
-class TestGCSObjectMetadataClient(unittest.TestCase):
-    def test_get_patched_obj_metadata(self):
-        param0 = luigi.OptionalParameter(default=None)
-        param1 = luigi.Parameter(default='param1_value')
-        param2 = luigi.IntParameter(default=100)
-        param3 = luigi.BoolParameter(default=False)
-        param4 = luigi.OptionalStrParameter(default='optional string')
-        param5 = luigi.DateParameter(default=datetime.date.today())
-        param6 = luigi.MonthParameter(default=datetime.date.today())
-        param7 = luigi.YearParameter(default=datetime.date.today())
-        param8 = luigi.DateHourParameter(default=datetime.date.today())
-        param9 = luigi.DateMinuteParameter(default=datetime.date.today())
-        param10 = luigi.DateSecondParameter(default=datetime.date.today())
+class _DummyTask(luigi.Task):
+    def run(self):
+        print(f"{self.__class__.__name__} has been executed")
 
+    def complete(self):
+        return True
+
+class _DummyEnum(enum.Enum):
+    hoge = 1
+    fuga = 2
+    geho = 3
+
+
+class TestGCSObjectMetadataClient(unittest.TestCase):
+    def test_get_patched_normal_parameter(self):
+        param1 = luigi.Parameter(default='param1_value')
         params = [
-            ('param0', None, param0),
             ('param1', 'param1_value', param1),
-            ('param2', 100, param2),
-            ('param3', False, param3),
-            ('param4', 'optional string', param4),
-            ('param5', datetime.date.today().strftime(param5.date_format), param5),
-            ('param6', datetime.date.today().strftime(param6.date_format), param6),
-            ('param7', datetime.date.today().strftime(param7.date_format), param7),
-            ('param8', datetime.date.today().strftime(param8.date_format), param8),
-            ('param9', datetime.date.today().strftime(param9.date_format), param9),
-            ('param10', datetime.date.today().strftime(param10.date_format), param10),
         ]
         want = {
             'param1': 'param1_value',
-            'param2': '100',
-            'param3': 'False',
-            'param4': 'optional string',
-            'param5': datetime.date.today().strftime(param5.date_format),
-            'param6': datetime.date.today().strftime(param6.date_format),
-            'param7': datetime.date.today().strftime(param7.date_format),
-            'param8': datetime.date.today().strftime(param8.date_format),
-            'param9': datetime.date.today().strftime(param9.date_format),
-            'param10': datetime.date.today().strftime(param10.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_parameter(self):
+        param1 = luigi.OptionalParameter(default=None)
+        param2 = luigi.OptionalParameter(default="optional")
+
+        params = [
+            ('param1', None, param1),
+            ('param2', 'optional', param2),
+        ]
+        want = {
+            'param2' : 'optional',
+        }
+
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_str_parameter(self):
+        param1 = luigi.OptionalStrParameter(default=None)
+        param2 = luigi.OptionalStrParameter(default='optional string')
+        params = [
+            ('param1', None, param1),
+            ('param2', 'optional string', param2),
+        ]
+        want = {
+            'param2': 'optional string',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_date_parameter(self):
+        param1 = luigi.DateParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+        ]
+        want = {
+            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_month_parameter(self):
+        param1 = luigi.MonthParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+        ]
+        want = {
+            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_year_parameter(self):
+        param1 = luigi.YearParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+        ]
+        want = {
+            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_date_hour_parameter(self):
+        param1 = luigi.DateHourParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+        ]
+        want = {
+            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_date_minute_parameter(self):
+        param1 = luigi.DateMinuteParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+        ]
+        want = {
+            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_date_second_parameter(self):
+        param1 = luigi.DateSecondParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+        ]
+        want = {
+            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_int_parameter(self):
+        param1 = luigi.IntParameter(default=100)
+        params = [
+            ('param1', 100, param1),
+        ]
+        want = {
+            'param1': '100',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_int_parameter(self):
+        param1 = luigi.OptionalIntParameter(default=None)
+        param2 = luigi.OptionalIntParameter(default=10)
+        params = [
+            ('param1', None, param1),
+            ('param2', 10, param2)
+        ]
+        want = {
+            'param2': '10',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_float_parameter(self):
+        param1 = luigi.FloatParameter(default=1.234)
+        params = [
+            ('param1', 1.234, param1),
+        ]
+        want = {
+            'param1': '1.234',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_float_parameter(self):
+        param1 = luigi.OptionalFloatParameter(default=None)
+        param2 = luigi.OptionalFloatParameter(default=12.345)
+        params = [
+            ('param1', None, param1),
+            ('param2', 12.345, param2),
+        ]
+        want = {
+            'param2': '12.345',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_bool_parameter(self):
+        param1 = luigi.BoolParameter(default=False)
+        params = [
+            ('param1', False, param1),
+        ]
+        want = {
+            'param1': 'False',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_bool_parameter(self):
+        param1 = luigi.OptionalBoolParameter(default=None)
+        param2 = luigi.OptionalBoolParameter(default=True)
+        params = [
+            ('param1', None, param1),
+            ('param2', True, param2),
+        ]
+        want = {
+            'param2': 'True',
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_date_interval_parameter(self):
+        param1 = luigi.DateIntervalParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        params = [
+            ('param1', datetime.datetime(2025, 2, 27, 0, 0), param1),
+        ]
+        want = {
+            'param1': str(datetime.datetime(2025, 2, 27, 0, 0)),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_time_delta_parameter(self):
+        param1 = luigi.TimeDeltaParameter(default=datetime.timedelta(hours=1))
+        params = [
+            ('param1', datetime.timedelta(hours=1), param1),
+        ]
+        want = {
+            'param1': str(datetime.timedelta(hours=1)),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_task_parameter(self):
+        param1 = luigi.TaskParameter(default=_DummyTask())
+        params = [
+            ('param1', _DummyTask(), param1),
+        ]
+        want = {
+            'param1': str(_DummyTask()),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_enum_parameter(self):
+        param1 = luigi.EnumParameter(enum=_DummyEnum, default=_DummyEnum.hoge)
+        params = [
+            ('param1', _DummyEnum.hoge, param1),
+        ]
+        want = {
+            'param1': str(_DummyEnum.hoge),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_enum_list_parameter(self):
+        param1 = luigi.EnumParameter(enum=_DummyEnum, default=[_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho])
+        params = [
+            ('param1', [_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho], param1),
+        ]
+        want = {
+            'param1': str([_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho]),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_dict_parameter(self):
+        param1 = luigi.DictParameter(default={"color":"red", "id": 123, "is_test": True})
+        params = [
+            ('param1', {"color":"red", "id": 123, "is_test": True}, param1),
+        ]
+        want = {
+            'param1': str({"color":"red", "id": 123, "is_test": True}),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_dict_parameter(self):
+        param1 = luigi.OptionalDictParameter(default=None)
+        param2 = luigi.OptionalDictParameter(default={"color": "red", "id": 123, "is_test": True})
+        params = [
+            ('param1', None, param1),
+            ('param2', {"color": "red", "id": 123, "is_test": True}, param2),
+        ]
+        want = {
+            'param2': str({"color": "red", "id": 123, "is_test": True}),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_list_parameter(self):
+        param1 = luigi.ListParameter(default=[1, 2, 3, 4, 5])
+        params = [
+            ('param1', [1, 2, 3, 4, 5], param1),
+        ]
+        want = {
+            'param1': str([1, 2, 3, 4, 5]),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_list_parameter(self):
+        param1 = luigi.OptionalListParameter(default=None)
+        param2 = luigi.ListParameter(default=[1, 2, 3, 4, 5])
+        params = [
+            ('param1', None, param1),
+            ('param2', [1, 2, 3, 4, 5], param2),
+        ]
+        want = {
+            'param2': str([1, 2, 3, 4, 5]),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_tuple_parameter(self):
+        param1 = luigi.TupleParameter(default=('hoge', 1, True, {'a': 'b'}))
+        params = [
+            ('param1', ('hoge', 1, True, {'a': 'b'}), param1),
+        ]
+        want = {
+            'param1': str(('hoge', 1, True, {'a': 'b'})),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_tuple_parameter(self):
+        param1 = luigi.OptionalTupleParameter(default=None)
+        param2 = luigi.TupleParameter(default=('hoge', 1, True, {'a': 'b'}))
+        params = [
+            ('param1', None, param1),
+            ('param2', ('hoge', 1, True, {'a': 'b'}), param2),
+        ]
+        want = {
+            'param2': str(('hoge', 1, True, {'a': 'b'})),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_path_parameter(self):
+        param1 = luigi.PathParameter(default="/hoge/fuga")
+        params = [
+            ('param1', "/hoge/fuga", param1),
+        ]
+        want = {
+            'param1': "/hoge/fuga",
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_optional_path_parameter(self):
+        param1 = luigi.OptionalPathParameter(default=None)
+        param2 = luigi.OptionalPathParameter(default="/hoge/fuga")
+        params = [
+            ('param1', None, param1),
+            ('param2', "/hoge/fuga", param2),
+        ]
+        want = {
+            'param2': "/hoge/fuga",
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(want, got)
+
+    def test_get_patched_obj_metadata_with_exceeded_size_metadata(self):
+        param1 = luigi.Parameter(default='a'*5000)
+        param2 = luigi.Parameter(default='b'*5000)
+
+        params = [
+            ('param1', 'a'*5000, param1),
+            ('param2', 'b' * 5000, param2),
+        ]
+
+        want = {
+            'param1': 'a'*5000,
         }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
         self.assertEqual(got, want)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -59,77 +59,75 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
             ('param1', None, param1),
             ('param2', 'optional string', param2),
         ]
-        want = {
-            'param2': 'optional string',
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertNotIn('param1', got)
+        self.assertIn('param2', got)
+        self.assertEqual('optional string', got['param2'])
 
     def test_get_patched_date_parameter(self):
-        param1 = luigi.DateParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.DateParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
         ]
-        want = {
-            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('6' in got['param1'])
+        self.assertFalse('4' in got['param1'])
 
     def test_get_patched_month_parameter(self):
-        param1 = luigi.MonthParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.MonthParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
         ]
-        want = {
-            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('5' in got['param1'])
+        self.assertFalse('6' in got['param1'])
 
     def test_get_patched_year_parameter(self):
-        param1 = luigi.YearParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.YearParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
         ]
-        want = {
-            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('1789' in got['param1'])
+        self.assertFalse('5' in got['param1'])
 
     def test_get_patched_date_hour_parameter(self):
-        param1 = luigi.DateHourParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.DateHourParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
         ]
-        want = {
-            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('4' in got['param1'])
+        self.assertFalse('2' in got['param1'])
 
     def test_get_patched_date_minute_parameter(self):
-        param1 = luigi.DateMinuteParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.DateMinuteParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
         ]
-        want = {
-            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('2' in got['param1'])
+        self.assertFalse('3' in got['param1'])
 
     def test_get_patched_date_second_parameter(self):
-        param1 = luigi.DateSecondParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.DateSecondParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3).strftime(param1.date_format), param1),
         ]
-        want = {
-            'param1': datetime.datetime(2025, 2, 27, 0, 0).strftime(param1.date_format),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('3' in got['param1'])
 
     def test_get_patched_int_parameter(self):
         param1 = luigi.IntParameter(default=100)
@@ -204,70 +202,72 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         self.assertEqual(want, got)
 
     def test_get_patched_date_interval_parameter(self):
-        param1 = luigi.DateIntervalParameter(default=datetime.datetime(2025, 2, 27, 0, 0))
+        param1 = luigi.DateIntervalParameter(default=datetime.datetime(1789, 5, 6, 4, 2, 3))
         params = [
-            ('param1', datetime.datetime(2025, 2, 27, 0, 0), param1),
+            ('param1', datetime.datetime(1789, 5, 6, 4, 2, 3), param1),
         ]
-        want = {
-            'param1': str(datetime.datetime(2025, 2, 27, 0, 0)),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertEqual(got['param1'], '1789-05-06 04:02:03')
 
     def test_get_patched_time_delta_parameter(self):
         param1 = luigi.TimeDeltaParameter(default=datetime.timedelta(hours=1))
         params = [
             ('param1', datetime.timedelta(hours=1), param1),
         ]
-        want = {
-            'param1': str(datetime.timedelta(hours=1)),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertEqual(got['param1'], '1:00:00')
 
     def test_get_patched_task_parameter(self):
         param1 = luigi.TaskParameter(default=_DummyTask())
         params = [
             ('param1', _DummyTask(), param1),
         ]
-        want = {
-            'param1': str(_DummyTask()),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('_DummyTask' in got['param1'])
 
     def test_get_patched_enum_parameter(self):
         param1 = luigi.EnumParameter(enum=_DummyEnum, default=_DummyEnum.hoge)
         params = [
             ('param1', _DummyEnum.hoge, param1),
         ]
-        want = {
-            'param1': str(_DummyEnum.hoge),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('_DummyEnum.hoge' in got['param1'])
 
     def test_get_patched_enum_list_parameter(self):
         param1 = luigi.EnumParameter(enum=_DummyEnum, default=[_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho])
         params = [
             ('param1', [_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho], param1),
         ]
-        want = {
-            'param1': str([_DummyEnum.hoge, _DummyEnum.fuga, _DummyEnum.geho]),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('_DummyEnum.hoge'in got['param1'])
+        self.assertTrue('_DummyEnum.fuga'in got['param1'])
+        self.assertTrue('_DummyEnum.geho'in got['param1'])
 
     def test_get_patched_dict_parameter(self):
         param1 = luigi.DictParameter(default={"color":"red", "id": 123, "is_test": True})
         params = [
             ('param1', {"color":"red", "id": 123, "is_test": True}, param1),
         ]
-        want = {
-            'param1': str({"color":"red", "id": 123, "is_test": True}),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('color' in got['param1'])
+        self.assertTrue('red' in got['param1'])
+        self.assertTrue('id' in got['param1'])
+        self.assertTrue('123' in got['param1'])
+        self.assertTrue('is_test' in got['param1'])
+        self.assertTrue('True' in got['param1'])
+
 
     def test_get_patched_optional_dict_parameter(self):
         param1 = luigi.OptionalDictParameter(default=None)
@@ -276,22 +276,30 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
             ('param1', None, param1),
             ('param2', {"color": "red", "id": 123, "is_test": True}, param2),
         ]
-        want = {
-            'param2': str({"color": "red", "id": 123, "is_test": True}),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertNotIn('param1', got)
+        self.assertIn('param2', got)
+        self.assertIsInstance(got['param2'], str)
+        self.assertTrue('color' in got['param2'])
+        self.assertTrue('red' in got['param2'])
+        self.assertTrue('id' in got['param2'])
+        self.assertTrue('123' in got['param2'])
+        self.assertTrue('is_test' in got['param2'])
+        self.assertTrue('True' in got['param2'])
 
     def test_get_patched_list_parameter(self):
         param1 = luigi.ListParameter(default=[1, 2, 3, 4, 5])
         params = [
             ('param1', [1, 2, 3, 4, 5], param1),
         ]
-        want = {
-            'param1': str([1, 2, 3, 4, 5]),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('1' in got['param1'])
+        self.assertTrue('2' in got['param1'])
+        self.assertTrue('3' in got['param1'])
+        self.assertTrue('4' in got['param1'])
+        self.assertTrue('5' in got['param1'])
 
     def test_get_patched_optional_list_parameter(self):
         param1 = luigi.OptionalListParameter(default=None)
@@ -300,22 +308,29 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
             ('param1', None, param1),
             ('param2', [1, 2, 3, 4, 5], param2),
         ]
-        want = {
-            'param2': str([1, 2, 3, 4, 5]),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertNotIn('param1', got)
+        self.assertIn('param2', got)
+        self.assertIsInstance(got['param2'], str)
+        self.assertTrue('1' in got['param2'])
+        self.assertTrue('2' in got['param2'])
+        self.assertTrue('3' in got['param2'])
+        self.assertTrue('4' in got['param2'])
+        self.assertTrue('5' in got['param2'])
 
     def test_get_patched_tuple_parameter(self):
         param1 = luigi.TupleParameter(default=('hoge', 1, True, {'a': 'b'}))
         params = [
             ('param1', ('hoge', 1, True, {'a': 'b'}), param1),
         ]
-        want = {
-            'param1': str(('hoge', 1, True, {'a': 'b'})),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('hoge' in got['param1'])
+        self.assertTrue('1' in got['param1'])
+        self.assertTrue('True' in got['param1'])
+        self.assertTrue('a' in got['param1'])
+        self.assertTrue('b' in got['param1'])
 
     def test_get_patched_optional_tuple_parameter(self):
         param1 = luigi.OptionalTupleParameter(default=None)
@@ -324,11 +339,15 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
             ('param1', None, param1),
             ('param2', ('hoge', 1, True, {'a': 'b'}), param2),
         ]
-        want = {
-            'param2': str(('hoge', 1, True, {'a': 'b'})),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertNotIn('param1', got)
+        self.assertIn('param2', got)
+        self.assertIsInstance(got['param2'], str)
+        self.assertTrue('hoge' in got['param2'])
+        self.assertTrue('1' in got['param2'])
+        self.assertTrue('True' in got['param2'])
+        self.assertTrue('a' in got['param2'])
+        self.assertTrue('b' in got['param2'])
 
     def test_get_patched_path_parameter(self):
         param1 = luigi.PathParameter(default="/hoge/fuga")
@@ -360,22 +379,18 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         params = [
             ('param1', str(_DummyTaskOnKart()), param1),
         ]
-        want = {
-            'param1': str(_DummyTaskOnKart()),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertIn('param1', got)
+        self.assertIsInstance(got['param1'], str)
+        self.assertTrue('_DummyTaskOnKart' in got['param1'])
 
     def test_get_patched_list_task_instance_parameter(self):
         param1 = gokart.ListTaskInstanceParameter(default=[_DummyTaskOnKart(), _DummyTaskOnKart()])
         params = [
             ('param1', str([_DummyTaskOnKart(), _DummyTaskOnKart()]), param1),
         ]
-        want = {
-            'param1': str([_DummyTaskOnKart(), _DummyTaskOnKart()]),
-        }
         got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
-        self.assertEqual(want, got)
+        self.assertTrue(got['param1'].count('_DummyTaskOnKart') == 2)
 
     def test_get_patched_explicit_bool_parameter(self):
         param1 = gokart.ExplicitBoolParameter(default=True)

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -1,0 +1,57 @@
+import datetime
+import unittest
+
+import luigi
+
+from gokart.gcs_obj_metadata_client import GCSObjectMetadataClient
+
+
+class TestGCSObjectMetadataClient(unittest.TestCase):
+    def test_get_patched_obj_metadata(self):
+        param0 = luigi.OptionalParameter(default=None)
+        param1 = luigi.Parameter(default='param1_value')
+        param2 = luigi.IntParameter(default=100)
+        param3 = luigi.BoolParameter(default=False)
+        param4 = luigi.OptionalStrParameter(default='optional string')
+        param5 = luigi.DateParameter(default=datetime.date.today())
+        param6 = luigi.MonthParameter(default=datetime.date.today())
+        param7 = luigi.YearParameter(default=datetime.date.today())
+        param8 = luigi.DateHourParameter(default=datetime.date.today())
+        param9 = luigi.DateMinuteParameter(default=datetime.date.today())
+        param10 = luigi.DateSecondParameter(default=datetime.date.today())
+        user_provided_gcs_labels = luigi.DictParameter(default={'hoge': 'fuga', '1': 2})
+
+        params = [
+            ('param0', None, param0),
+            ('param1', 'param1_value', param1),
+            ('param2', 100, param2),
+            ('param3', False, param3),
+            ('param4', 'optional string', param4),
+            ('param5', datetime.date.today().strftime(param5.date_format), param5),
+            ('param6', datetime.date.today().strftime(param6.date_format), param6),
+            ('param7', datetime.date.today().strftime(param7.date_format), param7),
+            ('param8', datetime.date.today().strftime(param8.date_format), param8),
+            ('param9', datetime.date.today().strftime(param9.date_format), param9),
+            ('param10', datetime.date.today().strftime(param10.date_format), param10),
+            ('user_provided_gcs_labels', {'hoge': 'fuga', '1': 2}, user_provided_gcs_labels),
+        ]
+        want = {
+            'hoge': 'fuga',
+            '1': '2',
+            'param1': 'param1_value',
+            'param2': '100',
+            'param3': 'False',
+            'param4': 'optional string',
+            'param5': datetime.date.today().strftime(param5.date_format),
+            'param6': datetime.date.today().strftime(param6.date_format),
+            'param7': datetime.date.today().strftime(param7.date_format),
+            'param8': datetime.date.today().strftime(param8.date_format),
+            'param9': datetime.date.today().strftime(param9.date_format),
+            'param10': datetime.date.today().strftime(param10.date_format),
+        }
+        got = GCSObjectMetadataClient._get_patched_obj_metadata({}, params=params)
+        self.assertEqual(got, want)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -19,7 +19,6 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         param8 = luigi.DateHourParameter(default=datetime.date.today())
         param9 = luigi.DateMinuteParameter(default=datetime.date.today())
         param10 = luigi.DateSecondParameter(default=datetime.date.today())
-        user_provided_gcs_labels = luigi.DictParameter(default={'hoge': 'fuga', '1': 2})
 
         params = [
             ('param0', None, param0),
@@ -33,11 +32,8 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
             ('param8', datetime.date.today().strftime(param8.date_format), param8),
             ('param9', datetime.date.today().strftime(param9.date_format), param9),
             ('param10', datetime.date.today().strftime(param10.date_format), param10),
-            ('user_provided_gcs_labels', {'hoge': 'fuga', '1': 2}, user_provided_gcs_labels),
         ]
         want = {
-            'hoge': 'fuga',
-            '1': '2',
             'param1': 'param1_value',
             'param2': '100',
             'param3': 'False',


### PR DESCRIPTION
## What does this PR do? 
This PR adds support for specifying labels when saving a task output to GCS.

## Why is this needed? 
Users of gokart can store some data like logs, results, parameter information etc. as cache in Google Cloud Storage(GCS).
But currently, gokart does not provide a way to add metadata labels when saving files to GCS.
So, it's so hard to track and filter the desired objects, data.
GCS has a useful field named custom object metadata, which can be added whatever you want as key-value.
So in this PR, support the way to provide this metadata to each object generated by gokart, easy to track and filter whatever you want.

## Checklist 
- CI is passing
- Code formatting follows project standards
- Necessary tests have been added
- Existing tests pass

