### PR TITLE
Fix a small bug for GCS object-custom-metadata size limitation.

### DIFF
--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -102,7 +102,7 @@ class GCSObjectMetadataClient:
         # Instead, users are expected to search using the labels they provided.
         # Therefore, in the event of a key conflict, the value registered by the user-provided labels will take precedence.
         _merged_labels = GCSObjectMetadataClient._merge_custom_labels_and_task_params_labels(normalized_task_params_labels, normalized_custom_labels)
-        return dict(metadata) | dict(GCSObjectMetadataClient._adjust_gcs_metadata_limit_size(_merged_labels))
+        return GCSObjectMetadataClient._adjust_gcs_metadata_limit_size(dict(metadata) | _merged_labels)
 
     @staticmethod
     def _merge_custom_labels_and_task_params_labels(


### PR DESCRIPTION
## Source of PR.
https://github.com/m3dev/gokart/pull/446
At last comments by @kitagry, current implementation would violate GCS object-custom-metadata size limitation.
Thanks for @kitagry.

## Description
Change `_get_patched_obj_metadata` implementation to follow GCS object-custom-metadata size limitation.
