### PR TITLE
Identify abortion with dumping empty DataFrame

### DIFF
--- a/docs/for_pandas.rst
+++ b/docs/for_pandas.rst
@@ -53,7 +53,7 @@ Please refer to :func:`~gokart.task.TaskOnKart.load`.
 Fail on empty DataFrame
 -----------------------
 
-When the :attr:`~gokart.task.TaskOnKart.fail_on_empty_dump` parameter is true, the :func:`~gokart.task.TaskOnKart.dump()` method is `AssertionError` on trying to dump empty ``pandas.DataFrame``.
+When the :attr:`~gokart.task.TaskOnKart.fail_on_empty_dump` parameter is true, the :func:`~gokart.task.TaskOnKart.dump()` method raises :class:`~gokart.task.EmptyDumpError` on trying to dump empty ``pandas.DataFrame``.
 
 
 .. code:: python
@@ -70,7 +70,7 @@ When the :attr:`~gokart.task.TaskOnKart.fail_on_empty_dump` parameter is true, t
 ::
 
     $ python main.py EmptyTask --fail-on-empty-dump true
-    # AssertionError
+    # EmptyDumpError
     $ python main.py EmptyTask
     # Task will be ran and outputs an empty dataframe
 

--- a/test/test_task_on_kart.py
+++ b/test/test_task_on_kart.py
@@ -14,6 +14,7 @@ import gokart
 from gokart.file_processor import XmlFileProcessor
 from gokart.parameter import ListTaskInstanceParameter, TaskInstanceParameter
 from gokart.target import ModelTarget, SingleFileTarget, TargetOnKart
+from gokart.task import EmptyDumpError
 
 
 class _DummyTask(gokart.TaskOnKart):
@@ -414,7 +415,7 @@ class TaskTest(unittest.TestCase):
 
         # fail
         task = _DummyTask(fail_on_empty_dump=True)
-        self.assertRaises(AssertionError, lambda: task.dump(pd.DataFrame()))
+        self.assertRaises(EmptyDumpError, lambda: task.dump(pd.DataFrame()))
 
     @patch('luigi.configuration.get_config')
     def test_add_configuration(self, mock_config: Mock):


### PR DESCRIPTION
## Objective

When a task failed and raised an exception, we want to identify whether its reason is dumping an empty DataFrame (with `fail_on_empty_dump` option) or the others.

## Implementation

Raise specific exception for that case.