### PR TITLE
simplify CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,18 +11,9 @@ jobs:
     strategy:
       max-parallel: 7
       matrix:
+        platform: ["ubuntu-latest"]
+        tox-env: ["py39", "py310", "py311", "py312", "py313"]
         include:
-          - platform: ubuntu-latest
-            tox-env: "py39"
-          - platform: ubuntu-latest
-            tox-env: "py310"
-          - platform: ubuntu-latest
-            tox-env: "py311"
-          - platform: ubuntu-latest
-            tox-env: "py312"
-          - platform: ubuntu-latest
-            tox-env: "py313"
-          # test only on latest python for macos
           - platform: macos-13
             tox-env: "py313"
           - platform: macos-latest


### PR DESCRIPTION
SSIA

In #433, we add CI running on macos but it made matrix representation complicated.
I found a simpler notation of this kind of CI matrix in the polars repo shown below:

https://github.com/pola-rs/polars/blob/d95e343e04d47bcbeafc815a2d9855aa5099f1bb/.github/workflows/test-python.yml#L40-L45