### PR TITLE
fix: raise GokartBuildError on FAILED_AND_SCHEDULING_FAILED status

### DIFF
--- a/gokart/build.py
+++ b/gokart/build.py
@@ -10,7 +10,7 @@ from typing import Literal, Protocol, TypeVar, cast, overload
 
 import backoff
 import luigi
-from luigi import rpc, scheduler
+from luigi import LuigiStatusCode, rpc, scheduler
 
 import gokart
 import gokart.tree.task_info
@@ -204,7 +204,7 @@ def build(
             )
             if task_lock_exception_raised.flag:
                 raise HasLockedTaskException()
-            if result.status == luigi.LuigiStatusCode.FAILED:
+            if result.status in (LuigiStatusCode.FAILED, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED, LuigiStatusCode.SCHEDULING_FAILED):
                 raise GokartBuildError(result.summary_text, raised_exceptions=raised_exceptions)
             return _get_output(task) if return_value else None
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -216,6 +216,43 @@ class TestBuildFailedAndSchedulingFailed(unittest.TestCase):
             with self.assertRaises(GokartBuildError):
                 gokart.build(_DummyTask(param='test'), reset_register=False, log_level=logging.CRITICAL)
 
+    def test_build_not_raises_exception_when_success_with_retry(self):
+        """Test that build() does not raise GokartBuildError when task succeeds with retry"""
+
+        # Create a mock result object with SUCCESS_WITH_RETRY status
+        class MockResult:
+            def __init__(self):
+                self.status = luigi.LuigiStatusCode.SUCCESS_WITH_RETRY
+                self.summary_text = 'Task completed successfully after retries'
+
+        # Mock _build_task to return a test value directly
+        with patch('luigi.build') as mock_luigi_build:
+            mock_luigi_build.return_value = MockResult()
+
+            # Create a mock task that will be used by build()
+            mock_task = _DummyTask(param='test')
+
+            # This should not raise GokartBuildError
+            # The test output will be whatever the mock returns
+            gokart.build(mock_task, reset_register=False, return_value=False, log_level=logging.CRITICAL)
+
+    def test_build_not_raises_exception_on_scheduling_failed_only(self):
+        """Test that build() raises GokartBuildError when SCHEDULING_FAILED occurs"""
+
+        # Create a mock result object with SCHEDULING_FAILED status
+        class MockResult:
+            def __init__(self):
+                self.status = luigi.LuigiStatusCode.SCHEDULING_FAILED
+                self.summary_text = 'Task scheduling failed'
+
+        # Mock luigi.build to return SCHEDULING_FAILED status
+        with patch('luigi.build') as mock_luigi_build:
+            mock_luigi_build.return_value = MockResult()
+
+            # This should raise GokartBuildError after the fix
+            with self.assertRaises(GokartBuildError):
+                gokart.build(_DummyTask(param='test'), reset_register=False, log_level=logging.CRITICAL)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request enhances error handling in `gokart` by extending the set of statuses that trigger exceptions during task builds and adding corresponding unit tests. The changes ensure more robust handling of scheduling failures and improve test coverage.