### PR TITLE
fix: gcs_object_metadata_client can't handle required_tasks

### DIFF
--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -120,7 +120,7 @@ class GCSObjectMetadataClient:
         elif isinstance(required_task_outputs, dict):
             return {k: GCSObjectMetadataClient._get_serialized_string(v) for k, v in required_task_outputs.items()}
         elif isinstance(required_task_outputs, Iterable):
-            return list([GCSObjectMetadataClient._get_serialized_string(ro) for ro in required_task_outputs])
+            return [GCSObjectMetadataClient._get_serialized_string(ro) for ro in required_task_outputs]
         else:
             raise TypeError(
                 f'Unsupported type for required_task_outputs: {type(required_task_outputs)}. '

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import gokart
 from gokart.gcs_obj_metadata_client import GCSObjectMetadataClient
+from gokart.required_task_output import RequiredTaskOutput
 from gokart.target import TargetOnKart
 
 
@@ -112,6 +113,18 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         self.assertEqual(got['empty'], 'True')
         self.assertEqual(got['created_by'], 'hoge fuga')
         self.assertEqual(got['param1'], 'a' * 10)
+
+    def test_get_patched_obj_metadata_with_required_task_outputs(self):
+        got = GCSObjectMetadataClient._get_patched_obj_metadata(
+            {},
+            required_task_outputs=[
+                RequiredTaskOutput(task_name='task1', output_path='path/to/output1'),
+            ],
+        )
+
+        self.assertIsInstance(got, dict)
+        self.assertIn('__required_task_outputs', got)
+        self.assertEqual(got['__required_task_outputs'], '[{"__gokart_task_name": "task1", "__gokart_output_path": "path/to/output1"}]')
 
 
 class TestGokartTask(unittest.TestCase):

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -126,6 +126,20 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         self.assertIn('__required_task_outputs', got)
         self.assertEqual(got['__required_task_outputs'], '[{"__gokart_task_name": "task1", "__gokart_output_path": "path/to/output1"}]')
 
+    def test_get_patched_obj_metadata_with_nested_required_task_outputs(self):
+        got = GCSObjectMetadataClient._get_patched_obj_metadata(
+            {},
+            required_task_outputs={
+                'nested_task': {'nest': RequiredTaskOutput(task_name='task1', output_path='path/to/output1')},
+            },
+        )
+
+        self.assertIsInstance(got, dict)
+        self.assertIn('__required_task_outputs', got)
+        self.assertEqual(
+            got['__required_task_outputs'], '{"nested_task": {"nest": {"__gokart_task_name": "task1", "__gokart_output_path": "path/to/output1"}}}'
+        )
+
 
 class TestGokartTask(unittest.TestCase):
     @patch.object(_DummyTaskOnKart, '_get_output_target')


### PR DESCRIPTION
fix #466 

This pull request fix the `_get_patched_obj_metadata` method in `gokart/gcs_obj_metadata_client.py`.
In original code, we doesn't consider `str` type, so RecursionError was occurred. like #466 .

In this PR, I made the code simple and add tests in order to check the behaviors.