### PR TITLE
Fix: dictionary changed size during iteration in GCSObjectMetadataClient

### DIFF
--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -159,10 +159,14 @@ class GCSObjectMetadataClient:
         )
         if current_total_metadata_size <= max_gcs_metadata_size:
             return labels
-        for label_name, label_value in reversed(labels.items()):
+        to_remove = []
+        for label_name, label_value in reversed(list(labels.items())):
             size = _get_label_size(label_name, label_value)
-            del labels[label_name]
+            to_remove.append(label_name)
             current_total_metadata_size -= size
             if current_total_metadata_size <= max_gcs_metadata_size:
                 break
+
+        for key in to_remove:
+            del labels[key]
         return labels

--- a/test/test_gcs_obj_metadata_client.py
+++ b/test/test_gcs_obj_metadata_client.py
@@ -139,6 +139,16 @@ class TestGCSObjectMetadataClient(unittest.TestCase):
         self.assertEqual(
             got['__required_task_outputs'], '{"nested_task": {"nest": {"__gokart_task_name": "task1", "__gokart_output_path": "path/to/output1"}}}'
         )
+        
+    def test_adjust_gcs_metadata_limit_size_runtime_error(self):
+        large_labels = {}
+        for i in range(100):
+            large_labels[f'key_{i}'] = 'x' * 1000
+            
+        result = GCSObjectMetadataClient._adjust_gcs_metadata_limit_size(large_labels)
+        
+        total_size = sum(len(k.encode('utf-8')) + len(v.encode('utf-8')) for k, v in result.items())
+        self.assertLessEqual(total_size, 8 * 1024)
 
 
 class TestGokartTask(unittest.TestCase):


### PR DESCRIPTION
The issue was in the _adjust_gcs_metadata_limit_size method where labels 
dictionary was being modified while iterating through it. Fixed by:
1. Creating a list of keys to remove first
2. Removing the keys after completing the iteration

This prevents the "dictionary changed size during iteration" error that 
occurred when large metadata needed to be adjusted to fit GCS size limits.