### PR TITLE
feat: add automatic processor selection based on DataFrame type parameter

### DIFF
--- a/gokart/file_processor/__init__.py
+++ b/gokart/file_processor/__init__.py
@@ -161,7 +161,7 @@ class FeatherFileProcessor(FileProcessor):
         return self._impl.dump(obj, file)
 
 
-def make_file_processor(file_path: str, dataframe_type: DataFrameType = 'pandas', store_index_in_feather: bool = True) -> FileProcessor:
+def make_file_processor(file_path: str, store_index_in_feather: bool = True, *, dataframe_type: DataFrameType = 'pandas') -> FileProcessor:
     """Create a file processor based on file extension with default parameters."""
     extension2processor = {
         '.txt': TextFileProcessor(),

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -236,16 +236,7 @@ class TaskOnKart(luigi.Task, Generic[T]):
             file_path=file_path, unique_id=unique_id, processor=processor, task_lock_params=task_lock_params, store_index_in_feather=self.store_index_in_feather
         )
 
-    def _create_processor_for_dataframe_type(self, file_path: str) -> FileProcessor | None:
-        """
-        Create a file processor with appropriate return_type based on task's type parameter.
-
-        Args:
-            file_path: Path to the file
-
-        Returns:
-            FileProcessor with return_type set, or None to use default processor
-        """
+    def _create_processor_for_dataframe_type(self, file_path: str) -> FileProcessor:
         df_type = get_dataframe_type_from_task(self)
         return make_file_processor(file_path, dataframe_type=df_type, store_index_in_feather=self.store_index_in_feather)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -168,3 +168,21 @@ class TestGetDataFrameTypeFromTask(unittest.TestCase):
 
         task = _DerivedLazyTask()
         self.assertEqual(get_dataframe_type_from_task(task), 'polars-lazy')
+
+    @pytest.mark.skipif(not HAS_POLARS, reason='polars not installed')
+    def test_nested_inheritance_polars_with_mixin(self):
+        """Derived class with multiple bases should still detect polars through MRO."""
+
+        class _Mixin:
+            pass
+
+        class _BasePolarsTaskWithMixin(TaskOnKart[pl.DataFrame]):
+            pass
+
+        # Multiple inheritance gives _DerivedTask its own __orig_bases__,
+        # which shadows the parent's and doesn't contain TaskOnKart[...].
+        class _DerivedTaskWithMixin(_BasePolarsTaskWithMixin, _Mixin):
+            pass
+
+        task = _DerivedTaskWithMixin()
+        self.assertEqual(get_dataframe_type_from_task(task), 'polars')


### PR DESCRIPTION
## Summary

This PR adds support for polars DataFrames alongside pandas DataFrames in gokart's file processors. Ta
sks can now specify their DataFrame type via the `TaskOnKart[T]` type parameter, and the appropriate pro
cessor will be automatically selected.

## Features

- **Auto-detection**: Automatically detects DataFrame type from `TaskOnKart[pd.DataFrame]` or `TaskOnK
art[pl.DataFrame]` type parameters
- **Backward compatible**: Defaults to pandas when no type parameter is specified

## Usage Example

```python
import polars as pl
from gokart import TaskOnKart

class MyPolarsTask(TaskOnKart[pl.DataFrame]):
    def output(self):
        return self.make_target('path/to/target.feather')

    def run(self):
        df = pl.DataFrame({'a': [1, 2, 3]})
        self.dump(df)  # Automatically uses polars-compatible processor

class MyPandasTask(TaskOnKart[pd.DataFrame]):
    def output(self):
        return self.make_target('path/to/target.feather')

    def run(self):
        df = pd.DataFrame({'a': [1, 2, 3]})
        self.dump(df)  # Uses pandas processor (default behavior)
```
