### PR TITLE
fix: correct typo in `_check_complete_value` causing AttributeError

### DIFF
--- a/gokart/worker.py
+++ b/gokart/worker.py
@@ -804,10 +804,10 @@ class Worker:
         elif not isinstance(dependency, Task):
             raise Exception(f'requires() must return Task objects but {dependency} is a {type(dependency)}')
 
-    def _check_complete_value(self, is_complete: bool) -> None:
-        if is_complete not in (True, False):
-            if isinstance(is_complete, luigi.worker.TracebackWrapper):
-                raise luigi.workerAsyncCompletionException(is_complete.trace)
+    def _check_complete_value(self, is_complete: bool | luigi.worker.TracebackWrapper) -> None:
+        if isinstance(is_complete, luigi.worker.TracebackWrapper):
+            raise luigi.worker.AsyncCompletionException(is_complete.trace)
+        if not isinstance(is_complete, bool):
             raise Exception(f'Return value of Task.complete() must be boolean (was {is_complete!r})')
 
     def _add_worker(self) -> None:

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -80,3 +80,25 @@ class TestWorkerSkipIfCompletedPreRun:
                 mock_run.assert_not_called()
             else:
                 mock_run.assert_called_once()
+
+
+class TestWorkerCheckCompleteValue:
+    def test_does_not_raise_for_boolean_values(self) -> None:
+        worker = Worker(scheduler=scheduler.Scheduler())
+        worker._check_complete_value(True)
+        worker._check_complete_value(False)
+
+    def test_raises_async_completion_exception_for_traceback_wrapper(self) -> None:
+        # NOTE: When Task.complete() raises in an async check, the exception is wrapped
+        #       in TracebackWrapper. This branch must raise AsyncCompletionException.
+        worker = Worker(scheduler=scheduler.Scheduler())
+        wrapped = luigi.worker.TracebackWrapper(trace='dummy traceback')
+        with pytest.raises(luigi.worker.AsyncCompletionException):
+            worker._check_complete_value(wrapped)
+
+    def test_raises_exception_for_non_boolean_value(self) -> None:
+        # NOTE: Pass a non-bool value to verify the runtime guard against a misimplemented
+        #       Task.complete() returning a non-boolean. The type ignore is intentional.
+        worker = Worker(scheduler=scheduler.Scheduler())
+        with pytest.raises(Exception, match='Return value of Task.complete'):
+            worker._check_complete_value('not a bool')  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Fix typo `luigi.workerAsyncCompletionException` -> `luigi.worker.AsyncCompletionException`. The missing dot raised `AttributeError` instead of the intended exception when `Task.complete()` failed and was wrapped in `TracebackWrapper`.
- Fix `is_complete` type hint to `bool | luigi.worker.TracebackWrapper`. The previous `bool` hint made type checkers treat the `TracebackWrapper` branch as unreachable, hiding the typo.
- Add regression tests for `_check_complete_value`.

## Test plan

- [x] `uv run pytest test/test_worker.py`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy gokart test`