### PR TITLE
Improve type definition of FlattenableItems for better type narrowing

### DIFF
--- a/gokart/gcs_obj_metadata_client.py
+++ b/gokart/gcs_obj_metadata_client.py
@@ -4,9 +4,8 @@ import copy
 import functools
 import json
 import re
-from collections.abc import Iterable
 from logging import getLogger
-from typing import Any, Final
+from typing import Any, Final, cast
 from urllib.parse import urlsplit
 
 from gokart.gcs_config import GCSConfig
@@ -125,10 +124,10 @@ class GCSObjectMetadataClient:
     @staticmethod
     def _get_serialized_string(required_task_outputs: FlattenableItems[RequiredTaskOutput]) -> FlattenableItems[str]:
         if isinstance(required_task_outputs, RequiredTaskOutput):
-            return required_task_outputs.serialize()
+            return cast(FlattenableItems[str], required_task_outputs.serialize())
         elif isinstance(required_task_outputs, dict):
             return {k: GCSObjectMetadataClient._get_serialized_string(v) for k, v in required_task_outputs.items()}
-        elif isinstance(required_task_outputs, Iterable):
+        elif isinstance(required_task_outputs, list | tuple):
             return [GCSObjectMetadataClient._get_serialized_string(ro) for ro in required_task_outputs]
         else:
             raise TypeError(

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -153,7 +153,9 @@ class TaskOnKart(luigi.Task, Generic[T]):
 
     def requires(self) -> FlattenableItems[TaskOnKart[Any]]:
         tasks = self.make_task_instance_dictionary()
-        return tasks or []  # when tasks is empty dict, then this returns empty list.
+        if tasks:
+            return cast(FlattenableItems[TaskOnKart[Any]], tasks)
+        return []  # when tasks is empty dict, then this returns empty list.
 
     def make_task_instance_dictionary(self) -> dict[str, TaskOnKart[Any]]:
         return {key: var for key, var in vars(self).items() if self.is_task_on_kart(var)}
@@ -354,9 +356,14 @@ class TaskOnKart(luigi.Task, Generic[T]):
             if isinstance(obj, pd.DataFrame) and obj.empty:
                 raise EmptyDumpError()
 
-        required_task_outputs = map_flattenable_items(
-            lambda task: map_flattenable_items(lambda output: RequiredTaskOutput(task_name=task.get_task_family(), output_path=output.path()), task.output()),
-            self.requires(),
+        required_task_outputs = cast(
+            FlattenableItems[RequiredTaskOutput],
+            map_flattenable_items(
+                lambda task: map_flattenable_items(
+                    lambda output: RequiredTaskOutput(task_name=task.get_task_family(), output_path=output.path()), task.output()
+                ),
+                self.requires(),
+            ),
         )
 
         self._get_output_target(target).dump(

--- a/gokart/utils.py
+++ b/gokart/utils.py
@@ -27,7 +27,7 @@ def add_config(file_path: str) -> None:
 
 
 T = TypeVar('T')
-FlattenableItems: TypeAlias = T | Iterable['FlattenableItems[T]'] | dict[str, 'FlattenableItems[T]']
+FlattenableItems: TypeAlias = T | list['FlattenableItems[T]'] | tuple['FlattenableItems[T]', ...] | dict[str, 'FlattenableItems[T]']
 
 
 def flatten(targets: FlattenableItems[T]) -> list[T]:
@@ -76,7 +76,7 @@ def map_flattenable_items(func: Callable[[T], K], items: FlattenableItems[T]) ->
         return tuple(map_flattenable_items(func, i) for i in items)
     if isinstance(items, str):
         return func(items)  # type: ignore
-    if isinstance(items, Iterable):
+    if isinstance(items, list):
         return list(map(lambda item: map_flattenable_items(func, item), items))
     return func(items)
 


### PR DESCRIPTION
## What I did

Replace `Iterable` with concrete collection types (`list`, `tuple`) in the `FlattenableItems` recursive type alias to enable proper type narrowing after `isinstance` checks.

```python
# before
FlattenableItems = T | Iterable[FlattenableItems[T]] | dict[str, FlattenableItems[T]]

# after
FlattenableItems = T | list[FlattenableItems[T]] | tuple[FlattenableItems[T], ...] | dict[str, FlattenableItems[T]]
```
Since dict, list, and tuple are disjoint, type checkers can now correctly narrow the type after isinstance(x, dict), resolving many false positives in Pyright and other modern type checker tools.

## Motivation
The original Iterable union prevented type narrowing because dict is a subtype of Iterable, making the branches overlap. 
This caused Pyright to report errors on dict indexing, return types, and argument types across task.py, utils.py, and gcs_obj_metadata_client.py.