### PR TITLE
Fix Pyright type errors in parameter.py and task.py

### DIFF
--- a/gokart/parameter.py
+++ b/gokart/parameter.py
@@ -114,7 +114,7 @@ class ListTaskInstanceParameter(luigi.Parameter[list[TASK_ON_KART_TYPE]], Generi
 
 class ExplicitBoolParameter(luigi.BoolParameter):
     def __init__(self, *args, **kwargs):
-        luigi.Parameter.__init__(self, *args, **kwargs)
+        super(luigi.BoolParameter, self).__init__(*args, **kwargs)
 
     def _parser_kwargs(self, *args, **kwargs):  # type: ignore
         return luigi.Parameter._parser_kwargs(*args, *kwargs)

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -395,7 +395,7 @@ class TaskOnKart(luigi.Task, Generic[T]):
 
             return task.to_str_params(only_significant=True)
 
-        dependencies = [_to_str_params(task) for task in flatten(self.requires())]
+        dependencies: list[Any] = [_to_str_params(task) for task in flatten(self.requires())]
         dependencies = [d for d in dependencies if d is not None]
         dependencies.append(self.to_str_params(only_significant=True))
         dependencies.append(self.__class__.__name__)

--- a/gokart/task.py
+++ b/gokart/task.py
@@ -438,7 +438,7 @@ class TaskOnKart(luigi.Task, Generic[T]):
         for param_name, param_value in self.param_kwargs.items():
             if (not only_significant) or params[param_name].significant:
                 if isinstance(params[param_name], gokart.TaskInstanceParameter):
-                    params_str[param_name] = type(param_value).__name__ + '-' + param_value.make_unique_id()
+                    params_str[param_name] = type(param_value).__name__ + '-' + cast(TaskOnKart[Any], param_value).make_unique_id()
                 else:
                     params_str[param_name] = params[param_name].serialize(param_value)
         return params_str


### PR DESCRIPTION
In this PR, I fix following type errors:

- `parameter.py` — Use `super(BoolParameter, self).__init__()` instead of `Parameter.__init__(self)` in `ExplicitBoolParameter` to avoid Pyright invariance error (`Parameter[bool]` vs `Parameter[str]`)
- `task.py:398` — Annotate `dependencies` as `list[Any]` since it contains both `str` and `dict[str, str]` values
- `task.py:441` — Cast `param_value` to `TaskOnKart[Any]` before calling `.make_unique_id()` in `get_info()`