### PR TITLE
fix: CsvFileProcessorPolars does not correctly support non-utf8 encoding

### DIFF
--- a/gokart/file_processor/polars.py
+++ b/gokart/file_processor/polars.py
@@ -12,7 +12,6 @@ from luigi.format import TextFormat
 from gokart.file_processor.base import FileProcessor
 from gokart.object_storage import ObjectStorage
 
-_CsvEncoding = Literal['utf8', 'utf8-lossy']
 _ParquetCompression = Literal['lz4', 'uncompressed', 'snappy', 'gzip', 'brotli', 'zstd']
 
 try:
@@ -41,13 +40,34 @@ class CsvFileProcessorPolars(FileProcessor):
         return TextFormat(encoding=self._encoding)
 
     def load(self, file):
+        is_utf8 = self._encoding in ('utf-8', 'utf8')
         try:
-            # scan_csv/read_csv only support 'utf8' and 'utf8-lossy'
-            encoding: _CsvEncoding = 'utf8' if self._encoding in ('utf-8', 'utf8') else 'utf8-lossy'
             if self._lazy:
+                if not is_utf8:
+                    # scan_csv reads directly from the file path and only understands
+                    # 'utf8'/'utf8-lossy', so it cannot correctly decode arbitrary
+                    # encodings such as 'cp932'. Silently falling back to
+                    # 'utf8-lossy' would just replace undecodable bytes instead of
+                    # actually decoding them, so we fail loudly instead.
+                    raise ValueError(
+                        f"CsvFileProcessorPolars(lazy=True) only supports encoding='utf-8', got encoding={self._encoding!r}. "
+                        'polars.scan_csv cannot decode arbitrary encodings while scanning a file lazily. '
+                        f'Use lazy=False to load a CSV file encoded as {self._encoding!r}.'
+                    )
                 # scan_csv requires a file path, not a file object
-                return pl.scan_csv(file.name, separator=self._sep, encoding=encoding)
-            return pl.read_csv(file, separator=self._sep, encoding=encoding)
+                return pl.scan_csv(file.name, separator=self._sep, encoding='utf8')
+
+            if is_utf8:
+                return pl.read_csv(file, separator=self._sep, encoding='utf8')
+
+            # `file` was opened by luigi using TextFormat(encoding=self._encoding),
+            # so reading from it already yields correctly-decoded text regardless
+            # of the original file encoding. Re-encode that text as UTF-8 bytes and
+            # let polars parse it as UTF-8, since polars.read_csv's own `encoding`
+            # argument only supports 'utf8' and 'utf8-lossy' and therefore cannot
+            # correctly decode arbitrary encodings such as 'cp932' on its own.
+            content = file.read()
+            return pl.read_csv(BytesIO(content.encode('utf-8')), separator=self._sep, encoding='utf8')
         except Exception as e:
             # Handle empty data gracefully
             if 'empty' in str(e).lower() or 'no data' in str(e).lower():
@@ -59,7 +79,18 @@ class CsvFileProcessorPolars(FileProcessor):
             obj = obj.collect()
         if not isinstance(obj, pl.DataFrame):
             raise TypeError(f'requires pl.DataFrame or pl.LazyFrame, but {type(obj)} is passed.')
-        obj.write_csv(file, separator=self._sep, include_header=True)
+
+        if self._encoding in ('utf-8', 'utf8'):
+            obj.write_csv(file, separator=self._sep, include_header=True)
+            return
+
+        # polars can only write CSV directly to a file-like object as UTF-8, and
+        # raises polars.exceptions.InvalidOperationError for any other encoding
+        # (even though `file` here was opened by luigi using
+        # TextFormat(encoding=self._encoding)). Get the CSV content as a string
+        # instead and let `file` apply the requested encoding when writing it.
+        csv_str = obj.write_csv(separator=self._sep, include_header=True)
+        file.write(csv_str)
 
 
 class JsonFileProcessorPolars(FileProcessor):

--- a/test/file_processor/test_polars.py
+++ b/test/file_processor/test_polars.py
@@ -123,6 +123,51 @@ class TestCsvFileProcessorWithPolars:
         processor = CsvFileProcessor(dataframe_type='polars')
         assert processor._dataframe_type == 'polars'
 
+    def test_dump_and_load_polars_with_non_utf8_encoding(self):
+        """Regression test: non-utf8 encodings (e.g. 'cp932') must not crash on dump
+        and must round-trip correctly on load, instead of silently reading back
+        incorrect ('utf8-lossy') data or raising polars.exceptions.InvalidOperationError.
+        """
+        df = pl.DataFrame({'name': ['\u4f50\u85e4', '\u9234\u6728']})
+        processor = CsvFileProcessor(encoding='cp932', dataframe_type='polars')
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = f'{temp_dir}/temp.csv'
+            local_target = LocalTarget(path=temp_path, format=processor.format())
+
+            with local_target.open('w') as f:
+                processor.dump(df, f)
+
+            # the file must actually be written using cp932 on disk, not utf-8
+            with open(temp_path, 'rb') as f:
+                raw = f.read()
+            assert raw == df.write_csv().encode('cp932')
+
+            with local_target.open('r') as f:
+                loaded_df = processor.load(f)
+
+            assert loaded_df.equals(df)
+
+    def test_polars_lazy_with_non_utf8_encoding_raises_clear_error(self):
+        """polars.scan_csv only supports 'utf8'/'utf8-lossy', so it cannot decode
+        arbitrary encodings while scanning a file lazily. Loading with
+        dataframe_type='polars-lazy' and a non-utf8 encoding should fail loudly
+        instead of silently returning lossily-decoded data.
+        """
+        df = pl.DataFrame({'name': ['\u4f50\u85e4', '\u9234\u6728']})
+        dump_processor = CsvFileProcessor(encoding='cp932', dataframe_type='polars')
+        lazy_processor = CsvFileProcessor(encoding='cp932', dataframe_type='polars-lazy')
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = f'{temp_dir}/temp.csv'
+            local_target = LocalTarget(path=temp_path, format=dump_processor.format())
+
+            with local_target.open('w') as f:
+                dump_processor.dump(df, f)
+
+            with local_target.open('r') as f, pytest.raises(ValueError, match='only supports'):
+                lazy_processor.load(f)
+
 
 @pytest.mark.skipif(not HAS_POLARS, reason='polars not installed')
 class TestJsonFileProcessorWithPolars:


### PR DESCRIPTION
## Problem

`CsvFileProcessor(dataframe_type='polars')` accepts an `encoding` parameter
(e.g. `encoding='cp932'`, as shown in gokart's own docs for Windows/Japanese
users), but it was effectively broken for anything other than utf-8:

- **dump()** crashed with `polars.exceptions.InvalidOperationError: file
  encoding is not UTF-8` when writing a CSV with a non-utf8 encoding, because
  `polars.DataFrame.write_csv()` can only write UTF-8 to a file-like object.
- **load()** with `dataframe_type='polars-lazy'` silently mapped any
  non-utf8 encoding to `'utf8-lossy'`. This does not actually decode the
  requested encoding — it just does a lossy UTF-8 decode — so it can
  silently return corrupted/garbled data with no error at all.

## Fix

- `dump()` now writes non-utf8 output through the file object that luigi
  already opened via `TextFormat(encoding=self._encoding)`, instead of
  relying on polars' own (UTF-8-only) file writing.
- `load()` (eager) reads the already-correctly-decoded text from that same
  file object and re-encodes it as UTF-8 bytes for polars to parse, instead
  of relying on polars' own `encoding` parameter (which only supports
  `'utf8'`/`'utf8-lossy'`).
- `load()` with `lazy=True` now raises a clear `ValueError` for non-utf8
  encodings, since `polars.scan_csv` cannot decode arbitrary encodings while
  scanning a file lazily — this is safer than silently corrupting data.

## Testing

Added 2 regression tests using `cp932`-encoded Japanese text:
- round-trip dump/load correctness (eager)
- clear error raised for lazy + non-utf8 encoding

All existing tests in `test/file_processor/test_polars.py` (33/33) pass,
and `ruff check` / `ruff format --check` report no new issues.